### PR TITLE
Feature: PDF consumer format

### DIFF
--- a/components/consumers/pdf/README.md
+++ b/components/consumers/pdf/README.md
@@ -1,0 +1,39 @@
+# PDF consumer
+
+This consumer prints the pipeline results into a Go template, prints them into a
+PDF and uploads them into an S3 bucket.
+
+# How it works
+
+The HTML template is in `/components/consumers/pdf/default.html` .\
+The styles for it are inline.\
+The PDF uses the Print styles, so it's slightly different from what you see in
+the browser.
+Then the component uses Playwright to render the template and print it into a
+PDF.
+The PDF is then uploaded into an S3 bucket.
+
+# How to test locally
+
+1. Install the requirements for the component. Check the Docker file (
+   `/components/consumers/pdf/Dockerfile`) for the
+   latest versions:
+
+```
+$ go install github.com/playwright-community/playwright-go/cmd/playwright@v0.4702.0
+$ playwright install chromium --with-deps
+```
+
+2. Generate the PDF by running this in the `smithy` oss repo root. We don't want
+   to upload to s3, so we add the `skips3`
+   flag. The template file is in the component folder:
+
+```
+go run components/consumers/pdf/main.go 
+-in components/consumers/pdf/example_data/gosec.enriched.aggregated.pb 
+-skips3 -template="components/consumers/pdf/default.html"
+```
+
+This generates the PDF and the report.html in the root of your repo, without
+uploading it to an S3 bucket. Don't forget
+to delete it later.

--- a/components/consumers/pdf/default.html
+++ b/components/consumers/pdf/default.html
@@ -8,9 +8,15 @@
     <style>
         body {
             font-family: 'Arial', sans-serif;
-            background-color: #f4f4f4;
-            color: #333;
+            color: #2b2722;
             margin: 20px;
+            -webkit-print-color-adjust: exact;
+        }
+
+        @media print {
+            .finding {
+                break-inside: avoid;
+            }
         }
 
         header {
@@ -22,23 +28,15 @@
             max-width: 100px;
             height: auto;
         }
+        h2 {
+            margin-top: 40px;
+            text-align: center;
+        }
 
         .report {
             max-width: 800px;
             margin: 0 auto;
-            padding: 20px;
             background-color: #fff;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-
-        .report-title {
-            font-size: 24px;
-            font-weight: bold;
-            color: #333;
-            text-align: center;
-            margin-bottom: 20px;
         }
 
         .scan {
@@ -48,136 +46,334 @@
         .scan-title {
             font-size: 20px;
             font-weight: bold;
-            color: #007bff;
+            color: #f65f1e;
             margin-bottom: 10px;
+            display: flex;
+            gap: 8px;
+            justify-content: center;
+        }
+        .scan-title span:not(:empty) + span::before{
+            content: ' - ';
         }
 
         .scan-details {
             margin-top: 10px;
-            color: #555;
         }
 
-        .finding {
-            border: 1px solid #eee;
-            border-radius: 5px;
-            margin: 15px 0;
-            padding: 15px;
-            background-color: #f9f9f9;
-            /* Alternating background color */
-        }
 
-        .finding:nth-child(even) {
-            background-color: #f5f5f5;
-            /* Alternating background color for even elements */
-        }
-
-        .finding-title {
-            font-size: 18px;
-            font-weight: bold;
-            color: #333;
-            margin-bottom: 10px;
-        }
-
-        .finding-details {
-            color: #777;
+        .summary {
+            margin-top: 30px;
         }
 
         .introduction {
-            margin-bottom: 20px;
-        }
-
-        .summary {
-            margin-top: 20px;
-            border-top: 1px solid #ddd;
-            padding-top: 20px;
-            color: #555;
+            text-align: center;
         }
 
         .placeholder-metrics {
             display: flex;
             justify-content: space-around;
-            margin-bottom: 20px;
+            margin-bottom: 30px;
+            gap: 10px;
         }
 
-        .placeholder-graph {
-            height: 200px;
-            background-color: #eaeaea;
-            border-radius: 5px;
+        .placeholder-metrics > div {
+            border-radius: 4px;
+            background-color: #fbf7f1;
+            border: 1px solid #d4c9b6;
+            flex-grow: 1;
+            text-align: center;
+            width: 50%;
+        }
+
+        .placeholder-metrics .high-severity {
+            background-color: #ffe3e3;
+            color: #982714;
+            border: 1px solid #ffb8b8;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid #d4c9b6;
+        }
+
+        table th {
+            background-color: #fbf7f1;
+        }
+
+        table th,
+        table td {
+            border: 1px solid #d4c9b6;
+            padding: 4px 10px;
+        }
+
+        .summary-table {
+            margin: 40px 0;
+        }
+
+        .summary-table th {
+            text-align: left;
+        }
+
+        /* Detailed finding list */
+        .scan-title,
+        .scan-details {
+            text-align: center;
+        }
+
+        .finding {
+            padding: 20px 0;
+        }
+
+        .finding-title {
+            font-size: 18px;
+            font-weight: bold;
+            margin: 0 0 10px;
+        }
+
+        .finding-table th {
+            text-align: right;
+            vertical-align: top;
+            width: 110px;
+        }
+
+        pre {
+            margin: 0;
+            font-size: 0.7em;
+        }
+
+        /*severities*/
+        .SEVERITY_CRITICAL {
+            background-color: #f88691;
+        }
+
+        .SEVERITY_HIGH {
+            background-color: #ffe3e3;
+        }
+
+        .SEVERITY_MEDIUM {
+            background-color: #fde8cb;
+        }
+
+        .SEVERITY_LOW {
+            background-color: #fdf7bd;
+        }
+
+        .SEVERITY_INFO {
+            background-color: #dafbfb;
+        }
+
+        .SEVERITY_UNSPECIFIED {
+            background-color: #fbf7f1;
+        }
+
+        .summary-table .new {
+            font-weight: bold;
         }
     </style>
 </head>
 
 <body>
 
-    <header>
-        <img src="https://github.com/smithy-security/smithy/raw/main/assets/smithy-logo-light.svg#gh-dark-mode-only" alt="Logo">
-        <h1>Smithy Report</h1>
-    </header>
+<header>
+    <a href="https://smithy.security"><img
+            src="https://github.com/smithy-security/smithy/raw/main/assets/smithy-logo-light.svg#gh-dark-mode-only"
+            alt="Logo"></a>
+    <h1>Smithy Report</h1>
+</header>
 
-    <div class="report">
-        <div class="report-title">Scan Results</div>
 
-        <!-- Introduction -->
-        <div class="introduction">
-            <p>This report summarizes the results of running Smithy.</p>
-        </div>
-        <!-- Summary -->
-        <div class="summary">
-            <h2>Summary</h2>
+<div class="report">
+    <div class="summary">
+        <p class="introduction">This report summarizes the results of running Smithy.</p>
 
-            <!-- Placeholder Metrics -->
-            <div class="placeholder-metrics">
-                <div>
-                    <h3>Total Number of Findings</h3>
-                    <p>10</p>
-                </div>
-                <div>
-                    <h3>Total High Severity Findings</h3>
-                    <p>10</p>
-                </div>
-            </div>
-
-            <!-- Placeholder Graph -->
-            <div class="placeholder-graph"></div>
-
-            <p>The vulnerability scans have identified potential issues that need attention. It is recommended to review
-                and address the findings promptly to enhance the security of our systems.</p>
+        <!-- Placeholder Metrics -->
+        <div class="placeholder-metrics">
+            <div class="high-severity"><h3><span id="total-high"></span> High Severity</h3></div>
+            <div><h3><span id="total"></span> Total</h3></div>
         </div>
 
-        <!-- Scan -->
-        {{range .}}
-        <div class="scan">
-            <div class="scan-title">{{.OriginalResults.ScanInfo.ScanUuid}} - {{.OriginalResults.ToolName}}</div>
-            <div class="scan-details">
-                <div><strong>Start Time:</strong> {{.OriginalResults.ScanInfo.ScanStartTime}}</div>
-            </div>
+        <table class="summary-table">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th style="width:95px">Seen before</th>
+                <th>Severity</th>
+            </tr>
+            </thead>
+            <tbody>
+            {{range .}}
             {{range .Issues}}
-            <div class="finding">
-                <div class="finding-title">{{.RawIssue.Title}}</div>
-                <div class="finding-details">
-                    <div>Target: {{.RawIssue.Target}} </div>
-                    <div>Type: {{.RawIssue.Type}} </div>
-                    <div>CVSS: {{.RawIssue.Cvss}} </div>
-                    <div>CVE: {{.RawIssue.Cve}} </div>
-                    <div>Confidence: {{.RawIssue.Confidence}} </div>
-                    <div>Severity: {{.RawIssue.Severity}} </div>
-                    <div>Description: {{.RawIssue.Description}} </div>
-                    <div>First Seen: {{.FirstSeen}} </div>
-                    <div>Seen Before Times: {{.Count}} </div>
-                    <div>False Positive?:{{.FalsePositive}} </div>
-                    <div>Last Updated: {{.UpdatedAt}} </div>
-                    {{ range $key,$element := .Annotations }}
-                    <p><b>{{$key}}</b>:{{$element}}</p>
-                    {{end}}
-                    <div>SBOM<pre>{{.RawIssue.CycloneDXSBOM}}</pre></div>
-                </div>
-            </div>
+            <tr class="issue-summary">
+                <td><a href="#{{ .RawIssue.Title | urlquery }}">{{.RawIssue.Title}}</a></td>
+                <td class="seen">{{.Count}} times</td>
+                <td class="summary severity {{.RawIssue.Severity}}">{{.RawIssue.Severity}} </td>
+            </tr>
+            {{ end }}
             {{end}}
+            </tbody>
+        </table>
+    </div>
 
-            <!-- Add more scans as needed -->
+    <h2>Detailed Results</h2>
 
+    <!-- Scan -->
+    {{range .}}
+    <div class="scan">
+        <h3 class="scan-title">{{.OriginalResults.ToolName}}</h3>
+        {{ if and .OriginalResults.ScanInfo.ScanStartTime (ne .OriginalResults.ScanInfo.ScanStartTime.Seconds 0) }}
+            <div class="scan-details">
+                <div class="scan-start-time">{{.OriginalResults.ScanInfo.ScanStartTime | formatTime}}</div>
+            </div>
+        {{ end }}
+        {{range .Issues}}
+        <div class="finding">
+            <h4 class="finding-title" id="{{ .RawIssue.Title | urlquery }}">{{ .RawIssue.Title }}</h4>
+            <table class="finding-table">
+                <tbody>
+
+                {{ if and .RawIssue.Severity (ne .RawIssue.Severity nil) }}
+                <tr>
+                    <th>Severity</th>
+                    <td class="severity {{.RawIssue.Severity}}">{{.RawIssue.Severity}}</td>
+                </tr>
+                {{ end }}
+
+                {{ if and .RawIssue.Cvss (ne .RawIssue.Cvss 0.0) }}
+                <tr>
+                    <th><a href="https://nvd.nist.gov/vuln-metrics/cvss">CVSS</a></th>
+                    <td>{{.RawIssue.Cvss}}</td>
+                </tr>
+                {{ end }}
+
+                {{ if and .RawIssue.Confidence (ne .RawIssue.Confidence nil) }}
+                <tr>
+                    <th>Confidence</th>
+                    <td class="confidence">{{.RawIssue.Confidence}}</td>
+                </tr>
+                {{ end }}
+
+                {{ if and .RawIssue.Type (ne .RawIssue.Type "") }}
+                <tr>
+                    <th>Type</th>
+                    <td>{{.RawIssue.Type}}</td>
+                </tr>
+                {{ end }}
+
+                {{ if and .RawIssue.Cve (ne .RawIssue.Cve "") }}
+                <tr>
+                    <th>CVE</th>
+                    <td>
+                        <a href="https://nvd.nist.gov/vuln/detail/{{.RawIssue.Cve}}">{{.RawIssue.Cve}}</a>
+                    </td>
+                </tr>
+                {{ end }}
+
+                {{if gt (len .RawIssue.Cwe) 0}}
+                    <tr class="cwe-list">
+                        <th>CWE</th>
+                        <td>
+                            {{range .RawIssue.Cwe}}
+                                <a href="https://cwe.mitre.org/data/definitions/{{ . }}.html">{{ . }}</a>
+                            {{end}}
+                        </td>
+                    </tr>
+                {{end}}
+
+                {{ if and .RawIssue.Target (ne .RawIssue.Target "") }}
+                <tr>
+                    <th>Target</th>
+                    <td>{{.RawIssue.Target}}</td>
+                </tr>
+                {{ end }}
+
+                {{ if and .RawIssue.Description (ne .RawIssue.Description "") }}
+                <tr>
+                    <th>Description</th>
+                    <td>
+                        <pre>{{.RawIssue.Description}}</pre>
+                    </td>
+                </tr>
+                {{ end }}
+
+                {{ if and .FirstSeen (ne .FirstSeen nil) }}
+                <tr>
+                    <th>First Seen</th>
+                    <td>{{.FirstSeen | formatTime}}</td>
+                </tr>
+                {{ end }}
+
+                <tr>
+                    <th>Seen Before</th>
+                    <td class="seen">{{.Count}} times</td>
+                </tr>
+
+                {{ if and .FalsePositive (ne .FalsePositive "") }}
+                <tr>
+                    <th>False Positive?</th>
+                    <td>{{.FalsePositive}}</td>
+                </tr>
+                {{ end }}
+
+                {{ if and .UpdatedAt (ne .UpdatedAt.Seconds 0) }}
+                <tr>
+                    <th>Last Updated</th>
+                    <td>{{ .UpdatedAt | formatTime }}</td>
+                </tr>
+                {{ end }}
+
+                {{ range $key,$element := .Annotations }}
+                <tr>
+                    <th>{{$key}}</th>
+                    <td>{{$element}}</td>
+                </tr>
+                {{end}}
+                </tbody>
+            </table>
+
+            {{ if .RawIssue.CycloneDXSBOM }}
+            <div class="sbom">
+                <h5>SBOM for {{.RawIssue.Title}}</h5>
+                <pre>{{ .RawIssue.CycloneDXSBOM }}</pre>
+            </div>
+            {{ end }}
         </div>
         {{end}}
-</body>
 
+        <!-- Add more scans as needed -->
+
+    </div>
+    {{end}}
+</div>
+
+</body>
+<footer>
+    <script>
+        // calculate totals
+        document.getElementById("total").innerHTML = document.querySelectorAll('.issue-summary').length;
+        document.getElementById("total-high").innerHTML = document.querySelectorAll('.summary.SEVERITY_CRITICAL').length + document.querySelectorAll('.summary.SEVERITY_HIGH').length;
+
+        // Remove the "SEVERITY_" prefix
+        document.querySelectorAll('.severity').forEach(function(element) {
+            if (element.textContent.startsWith("SEVERITY_")) {
+                element.textContent = element.textContent.replace("SEVERITY_", "");
+            }
+        });
+
+        // Remove the "CONFIDENCE_" prefix
+        document.querySelectorAll('.confidence').forEach(function(element) {
+            if (element.textContent.startsWith("CONFIDENCE_")) {
+                element.textContent = element.textContent.replace("CONFIDENCE_", "");
+            }
+        });
+
+        // Reformat ".seen" results to show which vulns are New
+        document.querySelectorAll('.seen').forEach(function(element) {
+            if (element.textContent === "0 times") {
+                element.textContent = element.textContent.replace("0 times", "Never");
+                element.classList.add("new");
+            }
+        });
+    </script>
+</footer>
 </html>

--- a/components/consumers/pdf/example_data/gosec.enriched.aggregated.pb
+++ b/components/consumers/pdf/example_data/gosec.enriched.aggregated.pb
@@ -1,0 +1,216 @@
+
+˜
+Ñ˜Í∑û–Ø–gosec€
+0file:///tmp/wspc/go-dvwa/vulnerable/sql.go:52-52G404VUse of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand) 0:?51: 			"sneaker",
+52: 			rand.Intn(500))
+53: 		if err != nil {
+BunknownR%:d01e22b2-88b0-4873-a13b-9e3d1279af09bœ			fmt.Sprintf("secret password %d", i))
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = db.Exec(
+			"INSERT INTO product (name, category, price) VALUES (?, ?, ?)",
+			fmt.Sprintf("Product %d", i),
+			"sneaker",
+			rand.Intn(500))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return db, nil
+}
+
+type Product struct {
+	Id       intj“î
+-file:///tmp/wspc/go-dvwa/server/main.go:27-27G114GUse of net/http serve function that has no support for setting timeouts 0:Ü26: 	log.Println("Serving application on", addr)
+27: 	err = http.ListenAndServe(addr, sqhttp.Middleware(router))
+28: 	if err != nil {
+BunknownR%:34ca912e-8df6-47f2-9bd9-7a1bd3771e81b“	if err != nil {
+		log.Panic("could not get the executable filename:", err)
+	}
+	templateDir := filepath.Join(filepath.Dir(bin), "template")
+
+	router := NewRouter(templateDir)
+
+	addr := ":8080"
+	log.Println("Serving application on", addr)
+	err = http.ListenAndServe(addr, sqhttp.Middleware(router))
+	if err != nil {
+		log.Fatalln(err)
+	}
+}j§ﬂ
+0file:///tmp/wspc/go-dvwa/vulnerable/sql.go:69-69G202SQL string concatenation 0:œ68: func GetProducts(ctx context.Context, db *sql.DB, category string) ([]Product, error) {
+69: 	rows, err := db.QueryContext(ctx, "SELECT * FROM product WHERE category='"+category+"'")
+70: 	if err != nil {
+BunknownR%:ff3580cd-5ce4-4f88-b125-e66a23dbc41abÅ
+type Product struct {
+	Id       int
+	Name     string
+	Category string
+	Price    string
+}
+
+func GetProducts(ctx context.Context, db *sql.DB, category string) ([]Product, error) {
+	rows, err := db.QueryContext(ctx, "SELECT * FROM product WHERE category='"+category+"'")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var products []Product
+	for rows.Next() {
+		var product Product
+		if err := rows.Scan(&product.Id, &product.Name, &product.Category, &product.Price); err != nil {
+			return nil, err
+		}jY‰
+1file:///tmp/wspc/go-dvwa/vulnerable/open.go:13-13G304%Potential file inclusion via variable 0:812: 	// restricted.
+13: 	return os.Open(filepath)
+14: }
+BunknownR%:9e858968-7fa7-44b4-9da6-960907c3db38bê
+package vulnerable
+
+import "os"
+
+func Open(filepath string) (*os.File, error) {
+	// Nothing special is needed to make Open vulnerable to local file inclusion
+	// (LFi). LFi is actually possible when the filepath is not properly
+	// restricted.
+	return os.Open(filepath)
+}jü
+/file:///tmp/wspc/go-dvwa/server/router.go:55-59G104Errors unhandled. 0:à54: 		enc := json.NewEncoder(w)
+55: 		enc.Encode(struct {
+56: 			Output string
+57: 		}{
+58: 			Output: string(output),
+59: 		})
+60: 	})
+BunknownR%:7f02a510-9b80-4bb6-a4ba-38fc53c6fe53bè		extra := r.FormValue("extra")
+		output, err := vulnerable.System(r.Context(), "ping -c1 sqreen.com"+extra)
+		if err != nil {
+			log.Println(err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		enc := json.NewEncoder(w)
+		enc.Encode(struct {
+			Output string
+		}{
+			Output: string(output),
+		})
+	})
+
+	r.PathPrefix("/").Handler(http.FileServer(http.Dir(templateDir)))
+
+	return r
+}jøﬁ
+€
+0file:///tmp/wspc/go-dvwa/vulnerable/sql.go:52-52G404VUse of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand) 0:?51: 			"sneaker",
+52: 			rand.Intn(500))
+53: 		if err != nil {
+BunknownR%:d01e22b2-88b0-4873-a13b-9e3d1279af09bœ			fmt.Sprintf("secret password %d", i))
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = db.Exec(
+			"INSERT INTO product (name, category, price) VALUES (?, ?, ?)",
+			fmt.Sprintf("Product %d", i),
+			"sneaker",
+			rand.Intn(500))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return db, nil
+}
+
+type Product struct {
+	Id       intj“ó
+î
+-file:///tmp/wspc/go-dvwa/server/main.go:27-27G114GUse of net/http serve function that has no support for setting timeouts 0:Ü26: 	log.Println("Serving application on", addr)
+27: 	err = http.ListenAndServe(addr, sqhttp.Middleware(router))
+28: 	if err != nil {
+BunknownR%:34ca912e-8df6-47f2-9bd9-7a1bd3771e81b“	if err != nil {
+		log.Panic("could not get the executable filename:", err)
+	}
+	templateDir := filepath.Join(filepath.Dir(bin), "template")
+
+	router := NewRouter(templateDir)
+
+	addr := ":8080"
+	log.Println("Serving application on", addr)
+	err = http.ListenAndServe(addr, sqhttp.Middleware(router))
+	if err != nil {
+		log.Fatalln(err)
+	}
+}j§‚
+ﬂ
+0file:///tmp/wspc/go-dvwa/vulnerable/sql.go:69-69G202SQL string concatenation 0:œ68: func GetProducts(ctx context.Context, db *sql.DB, category string) ([]Product, error) {
+69: 	rows, err := db.QueryContext(ctx, "SELECT * FROM product WHERE category='"+category+"'")
+70: 	if err != nil {
+BunknownR%:ff3580cd-5ce4-4f88-b125-e66a23dbc41abÅ
+type Product struct {
+	Id       int
+	Name     string
+	Category string
+	Price    string
+}
+
+func GetProducts(ctx context.Context, db *sql.DB, category string) ([]Product, error) {
+	rows, err := db.QueryContext(ctx, "SELECT * FROM product WHERE category='"+category+"'")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var products []Product
+	for rows.Next() {
+		var product Product
+		if err := rows.Scan(&product.Id, &product.Name, &product.Category, &product.Price); err != nil {
+			return nil, err
+		}jYÁ
+‰
+1file:///tmp/wspc/go-dvwa/vulnerable/open.go:13-13G304%Potential file inclusion via variable 0:812: 	// restricted.
+13: 	return os.Open(filepath)
+14: }
+BunknownR%:9e858968-7fa7-44b4-9da6-960907c3db38bê
+package vulnerable
+
+import "os"
+
+func Open(filepath string) (*os.File, error) {
+	// Nothing special is needed to make Open vulnerable to local file inclusion
+	// (LFi). LFi is actually possible when the filepath is not properly
+	// restricted.
+	return os.Open(filepath)
+}j¢
+ü
+/file:///tmp/wspc/go-dvwa/server/router.go:55-59G104Errors unhandled. 0:à54: 		enc := json.NewEncoder(w)
+55: 		enc.Encode(struct {
+56: 			Output string
+57: 		}{
+58: 			Output: string(output),
+59: 		})
+60: 	})
+BunknownR%:7f02a510-9b80-4bb6-a4ba-38fc53c6fe53bè		extra := r.FormValue("extra")
+		output, err := vulnerable.System(r.Context(), "ping -c1 sqreen.com"+extra)
+		if err != nil {
+			log.Println(err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		enc := json.NewEncoder(w)
+		enc.Encode(struct {
+			Output string
+		}{
+			Output: string(output),
+		})
+	})
+
+	r.PathPrefix("/").Handler(http.FileServer(http.Dir(templateDir)))
+
+	return r
+}jø

--- a/components/consumers/pdf/main_test.go
+++ b/components/consumers/pdf/main_test.go
@@ -42,7 +42,6 @@ func Test_run(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, pdfCalled)
 	require.True(t, s3Called)
-
 }
 
 func Test_buildPdf(t *testing.T) {


### PR DESCRIPTION
[Ticket](https://linear.app/smithy/issue/OCU-261/pdf-consumer-default-report-needs-styling)
This PR adds styles and a bit of logic to the PDF consumer.
- fix missing HTML file result
- calculate total and high priority findings
- summarise findings in a list with links to details
- hide empty vulnerability rows
- colour coding per priority
- parse dates and display them in a human format
- added link to CWE
- added test data into the folder
- add "seen before" to summary table at the top

![Screenshot from 2024-11-12 17-24-55](https://github.com/user-attachments/assets/027370be-451a-4aa4-ae3c-79d9e6a38d15)

[report.pdf](https://github.com/user-attachments/files/17720495/report.pdf)



