### PR TITLE
allow snyk node to be used for monorepos

### DIFF
--- a/components/producers/snyk-node/task.yaml
+++ b/components/producers/snyk-node/task.yaml
@@ -11,50 +11,45 @@ spec:
   params:
   - name: producer-snyk-node-api-key
     type: string
+  - name: producer-snyk-node-directories
+    type: array
+    default:
+    - .
   description: Run Snyk For Javascript, Typescript, Node
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: run-snyk
     imagePullPolicy: IfNotPresent
     env:
       - name: SNYK_INTEGRATION_VERSION 
         value: docker
-
-    image: 'snyk/snyk:node'
+    image: snyk/snyk:node
     script: |
       #!/usr/bin/env bash
-      set -x
-      set +e
+      set -ex
+
       echo "authenticating to snyk"
       snyk auth $(params.producer-snyk-node-api-key)
-      
+
       baseDir = $(pwd)
-      if [ ! -d $(workspaces.source-code.path)/node_modules ]; then
-        cd $(workspaces.source-code.path)/
+      cd $(workspaces.source-code.path)/
+      if [ -e yarn.lock ]
+      then
+        yarn install
+      else
         npm install
         exitCode=$?
-        if [[ $exitCode -eq 1 ]]; then
-          echo "npm install failed, trying yarn"
-           cd $(workspaces.source-code.path)/
-            yarn install
-          
-        fi
       fi
 
-      cd $baseDir
+      cd ${baseDir}
       echo "running snyk test"
       snyk test --prune-repeated-subdependencies --skip-unresolved --sarif-file-output=$(workspaces.scratch.path)/snyk.out $(workspaces.source-code.path)/
       exitCode=$?
-      if [[ $exitCode -ne 0 && $exitCode -ne 1 ]]; then
-        echo "Snyk failed with exit code $exitCode"
-        exit $exitCode
+      if [[ ${exitCode} -ne 0 && ${exitCode} -ne 1 ]]
+      then
+        echo "Snyk failed with exit code ${exitCode}"
+        exit ${exitCode}
       else
-        echo "Snyk completed successfully! exitcode $exitCode"
+        echo "Snyk completed successfully! exitcode ${exitCode}"
       fi
   - name: produce-issues
     imagePullPolicy: IfNotPresent

--- a/components/producers/snyk-node/task.yaml
+++ b/components/producers/snyk-node/task.yaml
@@ -30,8 +30,13 @@ spec:
       echo "authenticating to snyk"
       snyk auth $(params.producer-snyk-node-api-key)
 
-      baseDir = $(pwd)
-      cd $(workspaces.source-code.path)/
+
+      echo "Finding a file name `package.json` that is not in node_modules"
+      pkg=$( find $(workspaces.source-code.path) -name package.json -not -path "*/node_modules/*" | awk '{print length, $0}' | sort -n | head -n 1 | cut -d' ' -f2-)
+      echo "file package.json found in $(dirname $pkg)"
+
+      cd $(dirname $pkg)
+
       if [ -e yarn.lock ]
       then
         yarn install
@@ -40,9 +45,8 @@ spec:
         exitCode=$?
       fi
 
-      cd ${baseDir}
       echo "running snyk test"
-      snyk test --prune-repeated-subdependencies --skip-unresolved --sarif-file-output=$(workspaces.scratch.path)/snyk.out $(workspaces.source-code.path)/
+      snyk test --prune-repeated-subdependencies --skip-unresolved --sarif-file-output=$(workspaces.scratch.path)/snyk.out .
       exitCode=$?
       if [[ ${exitCode} -ne 0 && ${exitCode} -ne 1 ]]
       then
@@ -51,6 +55,7 @@ spec:
       else
         echo "Snyk completed successfully! exitcode ${exitCode}"
       fi
+      
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/snyk-docker:{{ .Chart.AppVersion }}'


### PR DESCRIPTION
our current snyk node component can only be used for repositories where the root folder is the one containing the NodeJS code, however it can't be used if the folder structure is any different or if there are multiple subfolder containing NodeJS projects.

this PR fixes this by allowing the user to define multiple paths to be scanned, and uses a better algorithm for deciding which package manager to use to resolve their dependencies. it stores the findings in a way that the parser can use to make sure that it has the full context about where they were discovered