### PR TITLE
refactor workspaces references across the old components

### DIFF
--- a/components/consumers/arangodb/task.yaml
+++ b/components/consumers/arangodb/task.yaml
@@ -16,7 +16,7 @@ spec:
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/consumers/arangodb:{{ .Chart.AppVersion }}'
     command: ["/app/components/consumers/arangodb/arangodb"]
     args: [
-      "-in", "$(workspaces.output.path)/.smithy/enrichers/",
+      "-in", "$(workspaces.scratch.path)/",
       "-db-url", "https://smithy.arangodb.svc:8529",
       "-db-name", "smithy",
       "-collection-name", "smithy",

--- a/components/consumers/aws-s3/task.yaml
+++ b/components/consumers/aws-s3/task.yaml
@@ -33,14 +33,10 @@ spec:
           value: "$(params.consumer-aws-s3-secret-access-key)"
       command: ["/app/components/consumers/aws-s3/aws-s3"]
       args:
-        [
-          "-in",
-          "$(workspaces.output.path)/.smithy/enrichers/",
-          "-bucket",
-          "$(params.consumer-aws-s3-bucket-name)",
-          "-region",
-          "$(params.consumer-aws-s3-bucket-region)",
-        ]
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
+        - -in
+        - $(workspaces.scratch.path)/
+        - -bucket
+        - $(params.consumer-aws-s3-bucket-name)
+        - -region
+        - $(params.consumer-aws-s3-bucket-region)
+

--- a/components/consumers/bigquery/task.yaml
+++ b/components/consumers/bigquery/task.yaml
@@ -29,7 +29,7 @@ spec:
       args:
         [
           "-in",
-          "$(workspaces.output.path)/.smithy/enrichers/",
+          "$(workspaces.scratch.path)/",
           "-project-id",
           "$(params.consumer-bigquery-project-id)",
           "-dataset",
@@ -38,5 +38,5 @@ spec:
           "$(params.consumer-bigquery-token)",
         ]
       volumeMounts:
-        - mountPath: /scratch
+        - mountPath: $(workspaces.scratch.path)
           name: scratch

--- a/components/consumers/defectdojo/task.yaml
+++ b/components/consumers/defectdojo/task.yaml
@@ -28,7 +28,7 @@ spec:
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/consumers/defectdojo:{{ .Chart.AppVersion }}'
     command: ["/app/components/consumers/defectdojo/defectdojo"]
     args: [
-      "-in", "$(workspaces.output.path)/.smithy/enrichers/",
+      "-in", "$(workspaces.scratch.path)/",
       "-dojoUser", "$(params.consumer-defectdojo-user)",
       "-dojoToken", "$(params.consumer-defectdojo-token)",
       "-dojoProductID", "$(params.consumer-defectdojo-product-id)",

--- a/components/consumers/dependency-track/task.yaml
+++ b/components/consumers/dependency-track/task.yaml
@@ -34,7 +34,7 @@ spec:
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/consumers/dependency-track:{{ .Chart.AppVersion }}'
     command: ["/app/components/consumers/dependency-track/dependency-track"]
     args: [
-      "-in", "$(workspaces.output.path)/.smithy/enrichers/",
+      "-in", "$(workspaces.scratch.path)/",
       "-url", "$(params.consumer-dependency-track-api-url)",
       "-apiKey", "$(params.consumer-dependency-track-token)",
       "-projectName", "$(params.consumer-dependency-track-project-name)",

--- a/components/consumers/elasticsearch/task.yaml
+++ b/components/consumers/elasticsearch/task.yaml
@@ -33,7 +33,7 @@ spec:
       command: ["/app/components/consumers/elasticsearch/elasticsearch"]
       args:
         - -in
-        - "$(workspaces.output.path)/.smithy/enrichers/"
+        - "$(workspaces.scratch.path)/"
         - -descriptionTemplate
         - "$(params.consumer-elasticsearch-description-template)"
         - -esIndex

--- a/components/consumers/jira/task.yaml
+++ b/components/consumers/jira/task.yaml
@@ -37,8 +37,8 @@ spec:
     imagePullPolicy: IfNotPresent
     image: docker.io/busybox:1.35.0
     script: |
-      mkdir -p $(workspaces.output.path)/.smithy/consumers/jira
-      cat <<'EOF' > $(workspaces.output.path)/.smithy/consumers/jira/config.json
+      mkdir -p $(workspaces.scratch.path)
+      cat <<'EOF' > $(workspaces.scratch.path)/config.json
        {
       "defaultValues": {
           "project": "$(params.consumer-jira-project-name)",
@@ -49,7 +49,7 @@ spec:
       "mappings": null
       }
       EOF
-      cat $(workspaces.output.path)/.smithy/consumers/jira/config.json
+      cat $(workspaces.scratch.path)/config.json
   - name: run-consumer
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/consumers/jira:{{ .Chart.AppVersion }}'
@@ -62,10 +62,10 @@ spec:
     - name: SMITHY_JIRA_URL
       value: $(params.consumer-jira-url)
     - name: SMITHY_JIRA_CONFIG_PATH
-      value: $(workspaces.output.path)/.smithy/consumers/jira/config.json
+      value: $(workspaces.scratch.path)/config.json
     args: [
       "-in",
-      "$(workspaces.output.path)/.smithy/enrichers/",
+      "$(workspaces.scratch.path)/",
       "-severity-threshold",
        "0"
     ]

--- a/components/consumers/mongodb/task.yaml
+++ b/components/consumers/mongodb/task.yaml
@@ -26,7 +26,7 @@ spec:
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/consumers/mongodb:{{ .Chart.AppVersion }}'
     command: ["/app/components/consumers/mongodb/mongodb"]
     args: [
-      "-in", "$(workspaces.output.path)/.smithy/enrichers/",
+      "-in", "$(workspaces.scratch.path)/",
       "-db-uri", "$(params.consumer-mongodb-db-uri)",
       "-db-name", "$(params.consumer-mongodb-db-name)",
       "-collection-name", "$(params.consumer-mongodb-collection-name)",

--- a/components/consumers/pdf/task.yaml
+++ b/components/consumers/pdf/task.yaml
@@ -39,7 +39,7 @@ spec:
       args:
         [
           "-in",
-          "$(workspaces.output.path)/.smithy/enrichers/",
+          "$(workspaces.scratch.path)/",
           "-bucket",
           "$(params.consumer-pdf-s3-bucket-name)",
           "-region",
@@ -47,6 +47,4 @@ spec:
           "-template",
           "$(params.consumer-pdf-template-location)",
         ]
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
+

--- a/components/consumers/slack/task.yaml
+++ b/components/consumers/slack/task.yaml
@@ -24,7 +24,7 @@ spec:
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/consumers/slack:{{ .Chart.AppVersion }}'
     command: ["/app/components/consumers/slack/slack"]
     args: [
-      "-in", "$(workspaces.output.path)/.smithy/enrichers/",
+      "-in", "$(workspaces.scratch.path)/",
       "-webhook", "$(params.consumer-slack-webhook)",
       "-template", "$(params.consumer-slack-message-template)",
     ]

--- a/components/consumers/stdout-json/task.yaml
+++ b/components/consumers/stdout-json/task.yaml
@@ -17,4 +17,4 @@ spec:
     command: ["/app/components/consumers/stdout-json/stdout-json"]
     args:
       - "-in"
-      - "$(workspaces.output.path)/.smithy/enrichers/"
+      - "$(workspaces.scratch.path)/"

--- a/components/enrichers/aggregator/task.yaml
+++ b/components/enrichers/aggregator/task.yaml
@@ -21,8 +21,8 @@ spec:
     command: ["/app/components/enrichers/aggregator/aggregator"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/enrichers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: "$(workspaces.output.path)/.smithy/enrichers"
+      value: "$(workspaces.scratch.path)"
     - name: B64_SIGNATURE_KEY
       value: "$(params.enricher-aggregator-b64-signature-key)"

--- a/components/enrichers/codeowners/task.yaml
+++ b/components/enrichers/codeowners/task.yaml
@@ -22,10 +22,10 @@ spec:
     command: ["/app/components/enrichers/codeowners/codeowners"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/producers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: "$(workspaces.output.path)/.smithy/enrichers/codeowners"
+      value: "$(workspaces.scratch.path)/codeowners"
     - name: REPO_BASE_PATH
-      value: "$(workspaces.output.path)/"
+      value: "$(workspaces.source-code.path)/"
     - name: ANNOTATION
       value: "$(params.enricher-codeowners-annotation)"

--- a/components/enrichers/custom-annotation/task.yaml
+++ b/components/enrichers/custom-annotation/task.yaml
@@ -26,9 +26,9 @@ spec:
     command: ["/app/components/enrichers/custom-annotation/custom-annotation"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/producers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: "$(workspaces.output.path)/.smithy/enrichers/custom-annotation"
+      value: "$(workspaces.scratch.path)/custom-annotation"
     - name: ANNOTATIONS
       value: "$(params.enricher-custom-annotation-base-annotation)"
     - name: NAME

--- a/components/enrichers/deduplication/task.yaml
+++ b/components/enrichers/deduplication/task.yaml
@@ -17,8 +17,8 @@ spec:
     command: ["/app/components/enrichers/deduplication/deduplication"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/producers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: $(workspaces.output.path)/.smithy/enrichers/deduplication
+      value: $(workspaces.scratch.path)/deduplication
     - name: DB_CONNECTION
       value: postgresql://{{.Values.database.auth.username}}:{{.Values.database.auth.password}}@{{.Values.database.host}}/{{.Values.database.auth.database}}?{{.Values.database.auth.querystringargs}}

--- a/components/enrichers/depsdev/task.yaml
+++ b/components/enrichers/depsdev/task.yaml
@@ -28,9 +28,9 @@ spec:
     command: ["/app/components/enrichers/depsdev/depsdev"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/producers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: "$(workspaces.output.path)/.smithy/enrichers/depsdev"
+      value: "$(workspaces.scratch.path)/depsdev"
     - name: LICENSES_IN_EVIDENCE
       value: "$(params.enricher-depsdev-licenses-in-evidence)"
     - name: ANNOTATION

--- a/components/enrichers/policy/task.yaml
+++ b/components/enrichers/policy/task.yaml
@@ -39,9 +39,9 @@ spec:
     command: ["/app/components/enrichers/policy/policy"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/producers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: "$(workspaces.output.path)/.smithy/enrichers/policy"
+      value: "$(workspaces.scratch.path)/policy"
     - name: POLICY
       value: "$(params.enricher-policy-base64-policy)"
     - name: OPA_SERVER

--- a/components/enrichers/reachability/task.yaml
+++ b/components/enrichers/reachability/task.yaml
@@ -10,12 +10,6 @@ spec:
   params:
     - name: enricher-reachability-programming-language
       type: string
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: run-cdxgen
     image: ghcr.io/cyclonedx/cdxgen:v10.9.5
@@ -29,34 +23,25 @@ spec:
       - -r
       - -p
       - -o
-      - $(workspaces.output.path)/source-code/bom.json
-      - $(workspaces.output.path)/source-code
+      - $(workspaces.source-code.path)/bom.json
+      - $(workspaces.source-code.path)
       - --spec-version
       - "1.5"
-    volumeMounts:
-      - mountPath: /scratch
-        name: scratch
   - name: run-atom
     imagePullPolicy: IfNotPresent
     image: ghcr.io/appthreat/atom:v2.0.18@sha256:893ed9ede9eea19540027faf72aa618e2b488192378f590fd2a1277b77712c1a
     command:
       - /bin/sh
       - -c
-      - atom reachables -o $(workspaces.output.path)/source-code/app.atom -s /scratch/reachables.json -l $(params.enricher-reachability-programming-language) $(workspaces.output.path)/source-code
-    volumeMounts:
-      - mountPath: /scratch
-        name: scratch
+      - atom reachables -o $(workspaces.source-code.path)/app.atom -s $(workspaces.scratch.path)/reachables.json -l $(params.enricher-reachability-programming-language) $(workspaces.source-code.path)
   - name: run-enricher
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/enrichers/reachability:{{ .Chart.AppVersion }}'
     command: ["/app/components/enrichers/reachability/reachability"]
-    volumeMounts:
-      - mountPath: /scratch
-        name: scratch
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/producers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: $(workspaces.output.path)/.smithy/enrichers/reachability
+      value: $(workspaces.scratch.path)/reachability
     - name: ATOM_FILE_PATH
-      value: /scratch/reachables.json
+      value: $(workspaces.scratch.path)/reachables.json

--- a/components/producers/aggregator/task.yaml
+++ b/components/producers/aggregator/task.yaml
@@ -9,20 +9,17 @@ spec:
   description: Combines multiple inputs into a single one.
   params: []
   results: []
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: aggregate
     image: docker.io/busybox
     command: ["ls"]
-    args: ["$(workspaces.output.path)"]
+    args: ["$(workspaces.source-code.path)"]
     env: []
   - name: tag
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/tagger:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/aggregator/tagger"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/producers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: "$(workspaces.output.path)/.smithy/producers"
+      value: "$(workspaces.scratch.path)"

--- a/components/producers/brakeman/task.yaml
+++ b/components/producers/brakeman/task.yaml
@@ -15,12 +15,6 @@ spec:
     default:
     - "--run-all-checks"
     - "--skip-libs"
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: run-brakeman
     image: presidentbeef/brakeman:v6.2.1.1
@@ -31,22 +25,16 @@ spec:
     - "json"
     - "--force-scan"
     - "--output"
-    - "/scratch/out.json"
+    - "$(workspaces.scratch.path)/out.json"
     - "-q"
     - "--path"
-    - "$(workspaces.output.path)/source-code/"
+    - "$(workspaces.source-code.path)/"
     - "--no-exit-on-error"
     - "--no-exit-on-warn"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/brakeman:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/brakeman/brakeman-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/brakeman.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/brakeman.pb"

--- a/components/producers/cdxgen/task.yaml
+++ b/components/producers/cdxgen/task.yaml
@@ -50,21 +50,14 @@ spec:
         - -r
         - -p
         - -o
-        - /scratch/out.json
-        - $(workspaces.output.path)/
+        - $(workspaces.scratch.path)/out.json
+        - $(workspaces.source-code.path)/
         - --spec-version
         - "1.5"
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
-
     - name: produce-issues
       imagePullPolicy: IfNotPresent
       image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/cdxgen:{{ .Chart.AppVersion }}'
       command: ["/app/components/producers/cdxgen/cdxgen-parser"]
       args:
-        - "-in=/scratch/out.json"
-        - "-out=$(workspaces.output.path)/.smithy/producers/cdxgen.pb"
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
+        - "-in=$(workspaces.scratch.path)/out.json"
+        - "-out=$(workspaces.scratch.path)/cdxgen.pb"

--- a/components/producers/checkov/task.yaml
+++ b/components/producers/checkov/task.yaml
@@ -13,12 +13,6 @@ spec:
   - name: producer-checkov-cyclonedx-target-override
     type: string
     default: ""
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: run-checkov
     image: bridgecrew/checkov:3.2.255
@@ -26,22 +20,16 @@ spec:
     args:
     - --skip-download
     - --directory
-    - "$(workspaces.output.path)/source-code"
+    - "$(workspaces.source-code.path)"
     - --output=cyclonedx_json
     - --output=sarif
     - --output-file-path
-    - /scratch    
+    - $(workspaces.scratch.path)    
     - --soft-fail
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch  
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/checkov:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/checkov/checkov-parser"]
     args:
-    - "-in=/scratch/results_sarif.sarif"
-    - "-out=$(workspaces.output.path)/.smithy/producers/checkov-sarif.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/results_sarif.sarif"
+    - "-out=$(workspaces.scratch.path)/checkov-sarif.pb"

--- a/components/producers/dependency-check/task.yaml
+++ b/components/producers/dependency-check/task.yaml
@@ -12,12 +12,6 @@ spec:
     - name: producer-dependency-check-nvd-api-key
       type: string
       default: ""
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: run-dependency-check
     image: owasp/dependency-check:10.0.3
@@ -28,19 +22,13 @@ spec:
     - -f
     - JSON
     - -o
-    - /scratch
+    - $(workspaces.scratch.path)/
     - -s
-    - $(workspaces.output.path)/
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - $(workspaces.source-code.path)/
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/dependency-check:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/dependency-check/dependency-check-parser"]
     args:
-    - "-in=/scratch/dependency-check-report.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/dependency-check.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/dependency-check-report.json"
+    - "-out=$(workspaces.scratch.path)/dependency-check.pb"

--- a/components/producers/dependency-track/task.yaml
+++ b/components/producers/dependency-track/task.yaml
@@ -20,12 +20,6 @@ spec:
   - name: producer-dependency-track-api-key
     type: string
     default: ""
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: source-code-ws
-      description: The workspace containing the dependency track results.
   steps:
   - name: produce-issues
     imagePullPolicy: IfNotPresent
@@ -36,8 +30,5 @@ spec:
     - "-projectID=$(params.producer-dependency-track-project-id)"
     - "-apiKey=$(params.producer-dependency-track-api-key)"
     - "-url=$(params.producer-dependency-track-url)"
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.source-code-ws.path)/.smithy/producers/dependency-track.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/dependency-track.pb"

--- a/components/producers/docker-trivy/task.yaml
+++ b/components/producers/docker-trivy/task.yaml
@@ -15,7 +15,7 @@ spec:
     description: Flags to pass to trivy. Optional.
   - name: producer-docker-trivy-target
     type: string
-    default: "$(workspaces.output.path)"
+    default: "$(workspaces.source-code.path)"
     description: The target to scan.
   - name: producer-docker-trivy-format
     type: string
@@ -25,12 +25,6 @@ spec:
     type: string
     default: image
     description: The command to run trivy with. Default `image`.
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: run-trivy
     image: docker.io/aquasec/trivy:0.54.1
@@ -40,21 +34,14 @@ spec:
     - -f
     - $(params.producer-docker-trivy-format)
     - -o
-    - /scratch/out.json
+    - $(workspaces.scratch.path)/out.json
     - $(params.producer-docker-trivy-command)
     - $(params.producer-docker-trivy-target)
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/docker-trivy:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/docker-trivy/docker-trivy-parser"]
     args:
     - "-format=$(params.producer-docker-trivy-format)"
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/docker-trivy.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/docker-trivy.pb"

--- a/components/producers/github-codeql/task.yaml
+++ b/components/producers/github-codeql/task.yaml
@@ -18,12 +18,6 @@ spec:
   - name: producer-github-codeql-github-token
     description: The GitHub token to use for scanning. Must have "Code scanning alerts" repository permissions (read).
     type: string
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: produce-issues
     imagePullPolicy: IfNotPresent
@@ -36,11 +30,8 @@ spec:
       - name: GITHUB_CLIENT_LIST_PAGE_SIZE
         value: "100"
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/github-codeql.pb"
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/github-codeql.pb"
     - "-github-token=$(params.producer-github-codeql-github-token)"
     - "-repository-owner=$(params.producer-github-codeql-repository-owner)"
     - "-repository-name=$(params.producer-github-codeql-repository-name)"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch

--- a/components/producers/github-dependabot/task.yaml
+++ b/components/producers/github-dependabot/task.yaml
@@ -18,12 +18,6 @@ spec:
   - name: producer-github-dependabot-github-token
     description: The GitHub token to use for scanning. Must have "Code scanning alerts" repository permissions (read).
     type: string
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: produce-issues
     imagePullPolicy: IfNotPresent
@@ -36,11 +30,8 @@ spec:
       - name: GITHUB_CLIENT_LIST_PAGE_SIZE
         value: "100"
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/github-dependabot.pb"
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/github-dependabot.pb"
     - "-github-token=$(params.producer-github-dependabot-github-token)"
     - "-repository-owner=$(params.producer-github-dependabot-repository-owner)"
     - "-repository-name=$(params.producer-github-dependabot-repository-name)"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch

--- a/components/producers/golang-gosec/task.yaml
+++ b/components/producers/golang-gosec/task.yaml
@@ -16,12 +16,6 @@ spec:
     - "-r"
     - "-sort"
     - "-nosec"
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: run-gosec
     image: docker.io/securego/gosec:2.15.0
@@ -29,19 +23,13 @@ spec:
     args:
     - "$(params.producer-golang-gosec-flags[*])"
     - "-fmt=json"
-    - "-out=/scratch/out.json"
+    - "-out=$(workspaces.scratch.path)/out.json"
     - "-no-fail"
-    - "$(workspaces.output.path)/source-code/..."
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "$(workspaces.source-code.path)/..."
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/golang-gosec:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/golang-gosec/golang-gosec-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/golang-gosec.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/golang-gosec.pb"

--- a/components/producers/golang-nancy/task.yaml
+++ b/components/producers/golang-nancy/task.yaml
@@ -14,58 +14,42 @@ spec:
       type: string
       default: "docker.io/golang:1.21"
       description: The container image that will be used to run Go nancy
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
     - name: go-deps
       image: "$(params.producer-golang-nancy-goImage)"
       script: | # necessary because sonatypecommunity/nancy does not include go
         #!/bin/bash -xe
         # make sure that the git repo is considered secure since it's mounted with onwen None but the process itself runs as root
-        git config --global --add safe.directory $(workspaces.output.path)/source-code
-        if [[ ! -f "$(workspaces.output.path)/source-code/Gopkg.lock" ]]; then
-           go_mod_paths=$(find $(workspaces.output.path)/source-code -iname "go.mod")
-           touch /scratch/golist.json
+        git config --global --add safe.directory $(workspaces.source-code.path)
+        if [[ ! -f "$(workspaces.source-code.path)/Gopkg.lock" ]]; then
+           go_mod_paths=$(find $(workspaces.source-code.path) -iname "go.mod")
+           touch $(workspaces.scratch.path)/golist.json
            for go_mod_path in $go_mod_paths; do
-             cd $(dirname $go_mod_path) && go list -json -deps ./... >> /scratch/golist.json
+             cd $(dirname $go_mod_path) && go list -json -deps ./... >> $(workspaces.scratch.path)/golist.json
            done
-           cat /scratch/golist.json
+           cat $(workspaces.scratch.path)/golist.json
          else
-           cat $(workspaces.output.path)/source-code/Gopkg.lock
+           cat $(workspaces.source-code.path)/Gopkg.lock
          fi
-         ls -lah /scratch
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
 
+         ls -lah $(workspaces.scratch.path)
     - name: run-nancy
       imagePullPolicy: IfNotPresent
       image: docker.io/sonatypecommunity/nancy:v1.0.42-alpine
       script: |
         #!/bin/sh
-        if [[ ! -f "$(workspaces.output.path)/source-code/Gopkg.lock" ]]; then
+        if [[ ! -f "$(workspaces.source-code.path)/Gopkg.lock" ]]; then
           echo "Running nancy with golist"
-          cat /scratch/golist.json | nancy sleuth -o json > /scratch/out.json || true
+          cat $(workspaces.scratch.path)/golist.json | nancy sleuth -o json > $(workspaces.scratch.path)/out.json || true
         else
           echo "Running nancy in dep mode"
-          nancy sleuth -p "$(workspaces.output.path)/source-code/Gopkg.lock" -o json > /scratch/out.json || true
+          nancy sleuth -p "$(workspaces.source-code.path)/Gopkg.lock" -o json > $(workspaces.scratch.path)/out.json || true
         fi
-        cat /scratch/out.json
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
-
+        cat $(workspaces.scratch.path)/out.json
     - name: produce-issues
       imagePullPolicy: IfNotPresent
       image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/golang-nancy:{{ .Chart.AppVersion }}'
       command: ["/app/components/producers/golang-nancy/golang-nancy-parser"]
       args:
-        - "-in=/scratch/out.json"
-        - "-out=$(workspaces.output.path)/.smithy/producers/golang-nancy.pb"
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
+        - "-in=$(workspaces.scratch.path)/out.json"
+        - "-out=$(workspaces.scratch.path)/golang-nancy.pb"

--- a/components/producers/java-findsecbugs/task.yaml
+++ b/components/producers/java-findsecbugs/task.yaml
@@ -24,7 +24,7 @@ spec:
   - name: get-jar
     image: busybox:latest
     script: |
-      wget "$(params.producer-java-findsecbugs-jar-url)" -O "$(workspaces.output.path)/main.jar"
+      wget "$(params.producer-java-findsecbugs-jar-url)" -O "$(workspaces.source-code.path)/main.jar"
   - name: run-findsecbugs
     imagePullPolicy: IfNotPresent
     image: docker.io/captainfoobar/findsecbugs:1.12.0.3
@@ -34,28 +34,18 @@ spec:
       - -xml
       - -progress
       - -output
-      - /scratch/out.xml
+      - $(workspaces.scratch.path)/out.xml
       - "$(params.producer-java-findsecbugs-extra-flags[*])"
-      - "$(workspaces.output.path)/main.jar"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+      - "$(workspaces.source-code.path)/main.jar"
   - name: debug
     imagePullPolicy: IfNotPresent
     image: busybox:latest
     script: |
-      ls -lah /scratch
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
+      ls -lah $(workspaces.scratch.path)
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/java-findsecbugs:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/java-findsecbugs/java-findsecbugs-parser"]
     args:
-    - "-in=/scratch/out.xml"
-    - "-out=$(workspaces.output.path)/.smithy/producers/java-findsecbugs.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.xml"
+    - "-out=$(workspaces.scratch.path)/java-findsecbugs.pb"

--- a/components/producers/kics/task.yaml
+++ b/components/producers/kics/task.yaml
@@ -21,18 +21,15 @@ spec:
       #!/bin/sh
       /app/bin/kics \
       scan \
-      -p $(workspaces.output.path) \
-      -o /scratch \
+      -p $(workspaces.source-code.path) \
+      -o $(workspaces.scratch.path) \
       --minimal-ui \
       --no-progress \
       --output-name out \
       --payload-lines \
       --report-formats json \
       --silent
-      cat /scratch/out.json
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+      cat $(workspaces.scratch.path)/out.json
     resources:
       requests:
         cpu: "500m"
@@ -43,8 +40,5 @@ spec:
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/kics:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/kics/kics-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/kics.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/kics.pb"

--- a/components/producers/ossf-scorecard/task.yaml
+++ b/components/producers/ossf-scorecard/task.yaml
@@ -32,19 +32,12 @@ spec:
     args:
       - --format=json
       - --show-details
-      - --output=/scratch/out.json
+      - --output=$(workspaces.scratch.path)/out.json
       - --repo=$(params.producer-ossf-scorecard-input-repo)
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/ossf-scorecard:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/ossf-scorecard/ossf-scorecard-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/ossf-scorecard.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/ossf-scorecard.pb"

--- a/components/producers/python-bandit/task.yaml
+++ b/components/producers/python-bandit/task.yaml
@@ -23,22 +23,15 @@ spec:
       pip3 install bandit
       bandit \
         --recursive \
-        $(workspaces.output.path) \
+        $(workspaces.source-code.path) \
         --format json \
-        --output /scratch/out.json \
+        --output $(workspaces.scratch.path)/out.json \
         || true
-      cat /scratch/out.json
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
+      cat $(workspaces.scratch.path)/out.json
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/python-bandit:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/python-bandit/python-bandit-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/python-bandit.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/python-bandit.pb"

--- a/components/producers/python-pip-safety/task.yaml
+++ b/components/producers/python-pip-safety/task.yaml
@@ -26,7 +26,7 @@ spec:
     script: |
       pip3 install safety
       set -x
-      cd $(workspaces.output.path)
+      cd $(workspaces.source-code.path)
       touch "uber-reqs.txt"
       for file in $(find . -iname "requirements.txt"); do
         cat $file >> "uber-reqs.txt"
@@ -34,17 +34,11 @@ spec:
 
       sort "uber-reqs.txt" | uniq -u > unique_requirements.txt
 
-      safety check -r unique_requirements.txt --save-json /scratch/out.json || true
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+      safety check -r unique_requirements.txt --save-json $(workspaces.scratch.path)/out.json || true
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/python-pip-safety:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/python-pip-safety/python-pip-safety-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/python-pip-safety.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/python-pip-safety.pb"

--- a/components/producers/semgrep/task.yaml
+++ b/components/producers/semgrep/task.yaml
@@ -29,36 +29,24 @@ spec:
       - name: SEMGREP_CONFIG
         value: $(params.producer-semgrep-rules-yaml)
     script: |
-      printf '%s' "${SEMGREP_CONFIG}" > "/scratch/semgrep-rules.yaml"
-      cat /scratch/semgrep-rules.yaml
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
+      printf '%s' "${SEMGREP_CONFIG}" > "$(workspaces.scratch.path)/semgrep-rules.yaml"
+      cat $(workspaces.scratch.path)/semgrep-rules.yaml
   - name: run-semgrep
     image: docker.io/returntocorp/semgrep:1.80
     command: ["semgrep"]
     args:
     - "scan"
     - "--config"
-    - "/scratch/semgrep-rules.yaml"
+    - "$(workspaces.scratch.path)/semgrep-rules.yaml"
     - "--config=$(params.producer-semgrep-config-value)"
     - "--json"
     - "--output"
-    - "/scratch/out.json"
-    - "$(workspaces.output.path)"
-
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
+    - "$(workspaces.scratch.path)/out.json"
+    - "$(workspaces.source-code.path)"
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/semgrep:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/semgrep/semgrep-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/semgrep.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/semgrep.pb"

--- a/components/producers/snyk-docker/task.yaml
+++ b/components/producers/snyk-docker/task.yaml
@@ -37,7 +37,7 @@ spec:
 
       echo "running snyk container test"
       snyk container test \
-        --sarif-file-output=/scratch/snyk.out \
+        --sarif-file-output=$(workspaces.scratch.path)/snyk.out \
         --docker \
         $(params.producer-snyk-docker-image)
 
@@ -48,17 +48,10 @@ spec:
       else
         echo "Snyk completed successfully! exitcode $exitCode"
       fi
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/snyk-docker:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/snyk-docker/snyk-docker-parser"]
     args:
-    - "-in=/scratch/snyk.out"
-    - "-out=$(workspaces.output.path)/.smithy/producers/snyk.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/snyk.out"
+    - "-out=$(workspaces.scratch.path)/snyk.pb"

--- a/components/producers/snyk-node/task.yaml
+++ b/components/producers/snyk-node/task.yaml
@@ -34,13 +34,13 @@ spec:
       snyk auth $(params.producer-snyk-node-api-key)
       
       baseDir = $(pwd)
-      if [ ! -d $(workspaces.output.path)/source-code/node_modules ]; then
-        cd $(workspaces.output.path)/source-code/
+      if [ ! -d $(workspaces.source-code.path)/node_modules ]; then
+        cd $(workspaces.source-code.path)/
         npm install
         exitCode=$?
         if [[ $exitCode -eq 1 ]]; then
           echo "npm install failed, trying yarn"
-           cd $(workspaces.output.path)/source-code/
+           cd $(workspaces.source-code.path)/
             yarn install
           
         fi
@@ -48,7 +48,7 @@ spec:
 
       cd $baseDir
       echo "running snyk test"
-      snyk test --prune-repeated-subdependencies --skip-unresolved --sarif-file-output=/scratch/snyk.out $(workspaces.output.path)/source-code/
+      snyk test --prune-repeated-subdependencies --skip-unresolved --sarif-file-output=$(workspaces.scratch.path)/snyk.out $(workspaces.source-code.path)/
       exitCode=$?
       if [[ $exitCode -ne 0 && $exitCode -ne 1 ]]; then
         echo "Snyk failed with exit code $exitCode"
@@ -56,18 +56,11 @@ spec:
       else
         echo "Snyk completed successfully! exitcode $exitCode"
       fi
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/snyk-docker:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/snyk-docker/snyk-docker-parser"]
     args:
-    - "-in=/scratch/snyk.out"
-    - "-out=$(workspaces.output.path)/.smithy/producers/snyk.pb"
+    - "-in=$(workspaces.scratch.path)/snyk.out"
+    - "-out=$(workspaces.scratch.path)/snyk.pb"
     - "-language=javascript"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch

--- a/components/producers/snyk-python/task.yaml
+++ b/components/producers/snyk-python/task.yaml
@@ -37,12 +37,12 @@ spec:
       snyk auth $(params.producer-snyk-python-api-key)
       if [[ -n "$(params.producer-snyk-python-relative-path-to-requirements-txt)" ]]; then
         echo "installing dependencies"
-        pip install --force --no-deps --no-compile --no-warn-conflicts -r "$(workspaces.output.path)/source-code/$(params.producer-snyk-python-relative-path-to-requirements-txt)"
+        pip install --force --no-deps --no-compile --no-warn-conflicts -r "$(workspaces.source-code.path)/$(params.producer-snyk-python-relative-path-to-requirements-txt)"
       fi
 
       echo "running snyk test"
-      ls -lah $(workspaces.output.path)/source-code/
-      snyk test --prune-repeated-subdependencies --skip-unresolved --sarif-file-output=/scratch/snyk.out $(workspaces.output.path)/source-code/
+      ls -lah $(workspaces.source-code.path)/
+      snyk test --prune-repeated-subdependencies --skip-unresolved --sarif-file-output=$(workspaces.scratch.path)/snyk.out $(workspaces.source-code.path)/
       exitCode=$?
       if [[ $exitCode -ne 0 && $exitCode -ne 1 ]]; then
         echo "Snyk failed with exit code $exitCode"
@@ -50,18 +50,11 @@ spec:
       else
         echo "Snyk completed successfully! exitcode $exitCode"
       fi
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/snyk-docker:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/snyk-docker/snyk-docker-parser"]
     args:
-    - "-in=/scratch/snyk.out"
-    - "-out=$(workspaces.output.path)/.smithy/producers/snyk.pb"
+    - "-in=$(workspaces.scratch.path)/snyk.out"
+    - "-out=$(workspaces.scratch.path)/snyk.pb"
     - "-language=python"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch

--- a/components/producers/terraform-tfsec/task.yaml
+++ b/components/producers/terraform-tfsec/task.yaml
@@ -22,24 +22,18 @@ spec:
     image: docker.io/aquasec/tfsec:v1.28
     command: [tfsec]
     args:
-    - $(workspaces.output.path)
+    - $(workspaces.source-code.path)
     - -f
     - json
     - --concise-output
     -  --out
-    - /scratch/out.json
+    - $(workspaces.scratch.path)/out.json
     - --soft-fail
     - "$(params.producer-terraform-tfsec-flags[*])"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/terraform-tfsec:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/terraform-tfsec/terraform-tfsec-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/terraform-tfsec.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/terraform-tfsec.pb"

--- a/components/producers/testsslsh/task.yaml
+++ b/components/producers/testsslsh/task.yaml
@@ -14,31 +14,19 @@ spec:
   - name: producer-testsslsh-flags
     type: array
     default: []
-  volumes:
-    - name: scratch
-      emptyDir: {}
-  workspaces:
-    - name: output
-      description: The workspace containing the source-code to scan.
   steps:
   - name: run-testsslsh
     image: docker.io/drwetter/testssl.sh:3.0
     command: ["/home/testssl/testssl.sh"]
     args:
       - --jsonfile
-      - /scratch/out.json
+      - $(workspaces.scratch.path)/out.json
       - "$(params.producer-testsslsh-flags[*])"
       - "$(params.producer-testsslsh-target-url)"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/testsslsh:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/testsslsh/testsslsh-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/testsslsh.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/testsslsh.pb"

--- a/components/producers/trufflehog/task.yaml
+++ b/components/producers/trufflehog/task.yaml
@@ -25,24 +25,18 @@ spec:
       set -xe
       mode='$(params.producer-trufflehog-git-repository)'
       if [[ -n "${mode}" ]]; then
-        trufflehog git --json "${mode}" &> /scratch/out.json
+        trufflehog git --json "${mode}" &> $(workspaces.scratch.path)/out.json
       else
         trufflehog \
           filesystem \
             --json \
-            --directory="$(workspaces.output.path)" &> /scratch/out.json
+            --directory="$(workspaces.source-code.path)" &> $(workspaces.scratch.path)/out.json
       fi
-      cat /scratch/out.json
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+      cat $(workspaces.scratch.path)/out.json
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/trufflehog:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/trufflehog/trufflehog-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/trufflehog.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/trufflehog.pb"

--- a/components/producers/typescript-eslint/eslint-wrapper/main.go
+++ b/components/producers/typescript-eslint/eslint-wrapper/main.go
@@ -37,7 +37,7 @@ func main() {
 		"json",
 		"--no-eslintrc",
 		"-o",
-		"/scratch/out.json",
+		"$(workspaces.scratch.path)/out.json",
 		"--exit-on-fatal-error",
 		"-c", ConfigPath, target).CombinedOutput()
 
@@ -46,7 +46,7 @@ func main() {
 		"-f",
 		"json",
 		"-o",
-		"/scratch/out.json",
+		"$(workspaces.scratch.path)/out.json",
 		"--exit-on-fatal-error",
 		"-c", ConfigPath, target)
 	log.Println("eslint out was", string(out))
@@ -57,7 +57,7 @@ func main() {
 			os.Exit(exitcode.ExitCode())
 		}
 	}
-	eslintOut, err := os.ReadFile("/scratch/out.json")
+	eslintOut, err := os.ReadFile("$(workspaces.scratch.path)/out.json")
 	if err != nil {
 		log.Println("could not read eslint output, err:")
 		panic(err)

--- a/components/producers/typescript-eslint/task.yaml
+++ b/components/producers/typescript-eslint/task.yaml
@@ -25,18 +25,12 @@ spec:
     command: ["/home/node/workspace/eslint-wrapper"]
     args:
      - -t
-     - $(workspaces.output.path)
+     - $(workspaces.source-code.path)
      - -c
      - "$(params.producer-typescript-eslint-config-js)"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
   - name: produce-issues
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/typescript-eslint:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/typescript-eslint/typescript-eslint-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/typescript-eslint.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/typescript-eslint.pb"

--- a/components/producers/typescript-yarn-audit/task.yaml
+++ b/components/producers/typescript-yarn-audit/task.yaml
@@ -20,22 +20,15 @@ spec:
       imagePullPolicy: IfNotPresent
       image: docker.io/node:lts
       script: |
-        cd $(workspaces.output.path)
+        cd $(workspaces.source-code.path)
         echo "Starting yarn audit command..."
-        yarn audit --json --silent --no-progress > /scratch/out.json || true
+        yarn audit --json --silent --no-progress > $(workspaces.scratch.path)/out.json || true
         echo "Done"
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
-
     - name: produce-issues
       imagePullPolicy: IfNotPresent
       image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/typescript-yarn-audit:{{ .Chart.AppVersion }}'
       command:
         ["/app/components/producers/typescript-yarn-audit/typescript-yarn-audit-parser"]
       args:
-        - "-in=/scratch/out.json"
-        - "-out=$(workspaces.output.path)/.smithy/producers/typescript-yarn-audit.pb"
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
+        - "-in=$(workspaces.scratch.path)/out.json"
+        - "-out=$(workspaces.scratch.path)/typescript-yarn-audit.pb"

--- a/components/producers/zaproxy/task.yaml
+++ b/components/producers/zaproxy/task.yaml
@@ -38,10 +38,10 @@ spec:
       if [ -z "$automation" ]; then 
         if [ -z  "$configFile" ]; then
           echo "Running ZAP with args: $(params.producer-zaproxy-flags)"
-          zap.sh -cmd -silent -notel -quickout /zap/wrk/out.json -quickurl $(params.producer-zaproxy-target) $(params.producer-zaproxy-flags)
+          zap.sh -cmd -silent -notel -quickout $(workspaces.scratch.path)/out.json -quickurl $(params.producer-zaproxy-target) $(params.producer-zaproxy-flags)
         else 
           echo "$configFile" | base64 -d > configuration.xml
-          zap.sh -cmd -silent -notel -quickout /zap/wrk/out.json -quickurl $(params.producer-zaproxy-target) -configFile configuration.xml
+          zap.sh -cmd -silent -notel -quickout $(workspaces.scratch.path)/out.json -quickurl $(params.producer-zaproxy-target) -configFile configuration.xml
           $(params.producer-zaproxy-flags)
         fi
       else 
@@ -49,17 +49,10 @@ spec:
         cat automation.yaml
         zap.sh -cmd -autorun automation.yaml
       fi
-    volumeMounts:
-    - mountPath: /zap/wrk
-      name: scratch
-
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/zaproxy:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/zaproxy/zaproxy-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/zap.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/zap.pb"

--- a/components/sources/dependency/task.yaml
+++ b/components/sources/dependency/task.yaml
@@ -27,4 +27,4 @@ spec:
       - "-purl"
       - "$(params.source-dependency-purl)"
       - "-outDir"
-      - "$(workspaces.output.path)"
+      - "$(workspaces.source-code.path)"

--- a/components/sources/git/task.yaml
+++ b/components/sources/git/task.yaml
@@ -13,29 +13,6 @@ metadata:
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 spec:
   description: Clone a Git repository from a remote origin.
-  workspaces:
-    - name: output
-      description: The git repo will be cloned onto the volume backing this Workspace.
-    - name: ssh-directory
-      optional: true
-      description: |
-        A .ssh directory with private key, known_hosts, config, etc. Copied to
-        the user's home before git commands are executed. Used to authenticate
-        with the git remote when performing the clone. Binding a Secret to this
-        Workspace is strongly recommended over other volume types.
-    - name: basic-auth
-      optional: true
-      description: |
-        A Workspace containing a .gitconfig and .git-credentials file. These
-        will be copied to the user's home before any git commands are run. Any
-        other files in this Workspace are ignored. It is strongly recommended
-        to use ssh-directory over basic-auth whenever possible and to bind a
-        Secret to this Workspace over other volume types.
-    - name: ssl-ca-directory
-      optional: true
-      description: |
-        A workspace containing CA certificates, this will be used by Git to
-        verify the peer with when fetching or pushing over HTTPS.
   params:
     - name: git-clone-url
       description: Repository URL to clone from.
@@ -67,7 +44,7 @@ spec:
     - name: git-clone-subdirectory
       description: Subdirectory inside the `output` Workspace to clone the repo into.
       type: string
-      default: "source-code"
+      default: ""
     - name: git-clone-sparseCheckoutDirectories
       description: Define the directory patterns to match or exclude when performing a sparse checkout.
       type: string
@@ -147,19 +124,7 @@ spec:
       - name: PARAM_USER_HOME
         value: $(params.git-clone-userHome)
       - name: WORKSPACE_OUTPUT_PATH
-        value: $(workspaces.output.path)
-      - name: WORKSPACE_SSH_DIRECTORY_BOUND
-        value: $(workspaces.ssh-directory.bound)
-      - name: WORKSPACE_SSH_DIRECTORY_PATH
-        value: $(workspaces.ssh-directory.path)
-      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
-        value: $(workspaces.basic-auth.bound)
-      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
-        value: $(workspaces.basic-auth.path)
-      - name: WORKSPACE_SSL_CA_DIRECTORY_BOUND
-        value: $(workspaces.ssl-ca-directory.bound)
-      - name: WORKSPACE_SSL_CA_DIRECTORY_PATH
-        value: $(workspaces.ssl-ca-directory.path)
+        value: $(workspaces.source-code.path)
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -171,25 +136,6 @@ spec:
           set -x
         fi
 
-        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
-          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
-          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
-          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
-          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
-        fi
-
-        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
-          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
-          chmod 700 "${PARAM_USER_HOME}"/.ssh
-          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
-        fi
-
-        if [ "${WORKSPACE_SSL_CA_DIRECTORY_BOUND}" = "true" ] ; then
-           export GIT_SSL_CAPATH="${WORKSPACE_SSL_CA_DIRECTORY_PATH}"
-           if [ "${PARAM_CRT_FILENAME}" != "" ] ; then
-              export GIT_SSL_CAINFO="${WORKSPACE_SSL_CA_DIRECTORY_PATH}/${PARAM_CRT_FILENAME}"
-           fi
-        fi
         CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
 
         cleandir() {

--- a/components/sources/wget/task.yaml
+++ b/components/sources/wget/task.yaml
@@ -11,12 +11,8 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.29.0"
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
     tekton.dev/tags: download
-
 spec:
   description: Download a file from a URL using wget.
-  workspaces:
-    - name: source-code-ws
-      description: The generated file will be stored onto the volume backing this Workspace.
   params:
     - name: wget-url
       description: The url we want to download file from
@@ -35,8 +31,6 @@ spec:
       image: "docker.io/library/buildpack-deps:stable-curl@sha256:3d5e59c47d5f82a769ad3f372cc9f86321e2e2905141bba974b75d3c08a53e8e"
       command: [wget]
       args:
-        [
-          "$(params.wget-options[*])",
-          "$(params.wget-url)",
-          "$(workspaces.source-code-ws.path)/$(params.wget-filename)",
-        ]
+        - $(params.wget-options[*])
+        - $(params.wget-url)
+        - $(workspaces.source-code.path)/$(params.wget-filename)

--- a/docs/extending/example-producer/task.yaml
+++ b/docs/extending/example-producer/task.yaml
@@ -27,20 +27,13 @@ spec:
     args:
     - "$(params.producer-example-tool-flags[*])"
     - "-fmt=json"
-    - "-out=/scratch/out.json"
+    - "-out=$(workspaces.scratch.path)/out.json"
     - "-no-fail"
-    - "$(workspaces.output.path)/..."
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
-
+    - "$(workspaces.source-code.path)/..."
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: {{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/example-tool:{{ .Chart.AppVersion }}
     command: ["/app/components/producers/example-tool/example-tool-parser"]
     args:
-    - "-in=/scratch/out.json"
-    - "-out=$(workspaces.output.path)/.smithy/producers/example-tool.pb"
-    volumeMounts:
-    - mountPath: /scratch
-      name: scratch
+    - "-in=$(workspaces.scratch.path)/out.json"
+    - "-out=$(workspaces.scratch.path)/example-tool.pb"

--- a/pkg/components/testdata/consumers/arangodb/task.yaml
+++ b/pkg/components/testdata/consumers/arangodb/task.yaml
@@ -15,7 +15,7 @@ spec:
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/consumers/arangodb:{{ .Chart.AppVersion }}'
     command: ["/app/components/consumers/arangodb/arangodb"]
     args: [
-      "-in", "$(workspaces.output.path)/.smithy/enrichers/",
+      "-in", "$(workspaces.scratch.path)/",
       "-db-url", "https://smithy.arangodb.svc:8529",
       "-db-name", "smithy",
       "-collection-name", "smithy",

--- a/pkg/components/testdata/enrichers/aggregator/task.yaml
+++ b/pkg/components/testdata/enrichers/aggregator/task.yaml
@@ -18,14 +18,14 @@ spec:
   - name: aggregate
     image: docker.io/busybox:1.35.0
     command: ["ls","-lah"]
-    args: ["$(workspaces.output.path)"]
+    args: ["$(workspaces.source-code.path)"]
   - name: aggregate-tagged-issues
     image:  '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/enrichers/aggregator:{{ .Chart.AppVersion }}'
     command: ["/app/components/enrichers/aggregator/aggregator"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/enrichers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: "$(workspaces.output.path)/.smithy/enrichers"
+      value: "$(workspaces.scratch.path)"
     - name: B64_SIGNATURE_KEY
       value: "$(params.enricher-aggregator-b64-signature-key)"

--- a/pkg/components/testdata/producers/aggregator/task.yaml
+++ b/pkg/components/testdata/producers/aggregator/task.yaml
@@ -15,13 +15,13 @@ spec:
   - name: aggregate
     image: docker.io/busybox
     command: ["ls"]
-    args: ["$(workspaces.output.path)"]
+    args: ["$(workspaces.scratch.path)"]
     env: []
   - name: tag
     image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/tagger:{{ .Chart.AppVersion }}'
     command: ["/app/components/producers/aggregator/tagger"]
     env:
     - name: READ_PATH
-      value: $(workspaces.output.path)/.smithy/producers
+      value: $(workspaces.scratch.path)
     - name: WRITE_PATH
-      value: "$(workspaces.output.path)/.smithy/producers"
+      value: $(workspaces.scratch.path)

--- a/pkg/components/testdata/producers/cdxgen/task.yaml
+++ b/pkg/components/testdata/producers/cdxgen/task.yaml
@@ -40,18 +40,11 @@ spec:
           value: $(params.producer-cdxgen-astgen-ignore-file-pattern)
         - name: ASTGEN_IGNORE_DIRS
           value: $(params.producer-cdxgen-astgen-ignore-dirs)
-      script: node /opt/cdxgen/bin/cdxgen.js -r -p -o /scratch/out.json $(workspaces.output.path)/ --spec-version 1.4
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
-
+      script: node /opt/cdxgen/bin/cdxgen.js -r -p -o $(workspaces.scratch.path)/out.json $(workspaces.source-code.path)/ --spec-version 1.4
     - name: produce-issues
       imagePullPolicy: IfNotPresent
       image: '{{ default "ghcr.io/smithy-security/smithy" .Values.image.registry }}/components/producers/cdxgen:{{ .Chart.AppVersion }}'
       command: ["/app/components/producers/cdxgen/cdxgen-parser"]
       args:
-        - "-in=/scratch/out.json"
-        - "-out=$(workspaces.output.path)/.smithy/producers/cdxgen.pb"
-      volumeMounts:
-        - mountPath: /scratch
-          name: scratch
+        - "-in=$(workspaces.scratch.path)/out.json"
+        - "-out=$(workspaces.scratch.path)/cdxgen.pb"

--- a/pkg/components/testdata/sources/git/task.yaml
+++ b/pkg/components/testdata/sources/git/task.yaml
@@ -156,19 +156,7 @@ spec:
       - name: PARAM_USER_HOME
         value: $(params.git-clone-userHome)
       - name: WORKSPACE_OUTPUT_PATH
-        value: $(workspaces.output.path)
-      - name: WORKSPACE_SSH_DIRECTORY_BOUND
-        value: $(workspaces.ssh-directory.bound)
-      - name: WORKSPACE_SSH_DIRECTORY_PATH
-        value: $(workspaces.ssh-directory.path)
-      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
-        value: $(workspaces.basic-auth.bound)
-      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
-        value: $(workspaces.basic-auth.path)
-      - name: WORKSPACE_SSL_CA_DIRECTORY_BOUND
-        value: $(workspaces.ssl-ca-directory.bound)
-      - name: WORKSPACE_SSL_CA_DIRECTORY_PATH
-        value: $(workspaces.ssl-ca-directory.path)
+        value: $(workspaces.source-code.path)
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
this PR refactors how we refer to workspaces so that we have a consistent way of defining what should be preserved between components and what is not needed. we are no longer tied to Tekton, our components are dynamically translated and this PR is the first one that completely breaks integration with Tekton.
the gist of the PR is that we are removing the workspaces sections and the volume mounts from all components since they are not used and forcing all components to use either a scratch workspace, which is a temporary folder, or a source-code folder where the source code is checked out by the git-clone component and then shared with other components. this allows to have a more consistent and precise definition of what each component requires, and the fact is that most of them just require access to the checked out code, the results are fetched by external subsystems.