### PR TITLE
fix revive scanning command in reviewdog since it doesn't handle monorepos well

### DIFF
--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -9,7 +9,9 @@ runner:
     format: staticcheck
 
   go/revive:
-    cmd: revive -exclude ./vendor/... -exclude ./api/proto/... -config revive.toml ./...
+    cmd: |
+      revive -exclude ./vendor/... -config revive.toml $(go list ./... | grep -v new-components) &&
+      CONFIG_FILE="$(pwd)/revive.toml" find ./new-components/ -name go.mod -type f -exec bash -c 'cd $(dirname {}) && revive -exclude ./vendor/... -config ${CONFIG_FILE} ./...' \;
     errorformat:
       - '%f:%l:%c: %m'
  

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ lint:
 	@reviewdog -fail-level=any -diff="git diff origin/main" -filter-mode=added 2>&1
 
 install-lint-tools:
-	GOTOOLCHAIN=go1.23.2 go install honnef.co/go/tools/cmd/staticcheck@2024.1.1
+	GOTOOLCHAIN=$$(go env GOVERSION) go install honnef.co/go/tools/cmd/staticcheck@2024.1.1
 	@go install github.com/mgechev/revive@v1.6.0
 	@go install github.com/sivchari/containedctx/cmd/containedctx@latest
 	@go install github.com/gordonklaus/ineffassign@latest

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ lint:
 	@reviewdog -fail-level=any -diff="git diff origin/main" -filter-mode=added 2>&1
 
 install-lint-tools:
-	@go install honnef.co/go/tools/cmd/staticcheck@latest
-	@go install github.com/mgechev/revive@latest
+	GOTOOLCHAIN=go1.23.2 go install honnef.co/go/tools/cmd/staticcheck@2024.1.1
+	@go install github.com/mgechev/revive@v1.6.0
 	@go install github.com/sivchari/containedctx/cmd/containedctx@latest
 	@go install github.com/gordonklaus/ineffassign@latest
 	@go install github.com/polyfloyd/go-errorlint@latest


### PR DESCRIPTION
in order to test this run locally: `make install-lint-tools list`