### PR TITLE
Adding importable Label to be used for moving to new components.

### DIFF
--- a/sdk/component/label.go
+++ b/sdk/component/label.go
@@ -1,0 +1,4 @@
+package component
+
+// SDKComponentLabel is a temporary label used to connect bits.
+const SDKComponentLabel = "sdk-component"


### PR DESCRIPTION
We need this bit so that we can tag correctly components in SAAS and deploy them separately from the old ones.