### PR TITLE
fixes ocu-503: allow helper images to be built for a component

### DIFF
--- a/smithyctl/internal/images/component.go
+++ b/smithyctl/internal/images/component.go
@@ -145,7 +145,7 @@ func ParseComponentRepository(componentPath, imageRef string, options ...Resolut
 	// some-folder/scanners/gosec. if this is not the case, it's not recognised
 	// as a Smithy component image reference and we will just return the parsed
 	// image reference.
-	if parsedRef.RepositoryStr() != componentDirectory {
+	if !strings.HasPrefix(parsedRef.RepositoryStr(), componentDirectory) {
 		return nil, &parsedRef, errors.Errorf("%s: %w", parsedRef.Name(), ErrNotAComponentRepo)
 	}
 
@@ -172,14 +172,18 @@ func ParseComponentRepository(componentPath, imageRef string, options ...Resolut
 		)
 	}
 
-	componentName := componentDirectoryParts[len(componentDirectoryParts)-1]
 	return &ComponentRepository{
 		repository:         parsedRef,
 		componentType:      componentType,
 		componentNamespace: opts.namespace,
-		componentName:      componentName,
-		directory:          componentDirectory,
-		extraTags:          opts.extraTags,
+		componentName: strings.TrimLeft(
+			strings.Replace(
+				parsedRef.RepositoryStr(),
+				path.Dir(componentDirectory), "", -1),
+			"/",
+		),
+		directory: parsedRef.RepositoryStr(),
+		extraTags: opts.extraTags,
 	}, &parsedRef, nil
 }
 

--- a/smithyctl/internal/images/component_test.go
+++ b/smithyctl/internal/images/component_test.go
@@ -82,4 +82,29 @@ func TestComponentDirectory(t *testing.T) {
 		},
 		cr.URLs(),
 	)
+
+	cr, _, err = ParseComponentRepository(
+		"new-components/scanners/some-component/component.yaml",
+		"new-components/scanners/some-component/helper",
+		WithNamespace("some/namespace"),
+		WithRegistry("kind-registry:5000"),
+		WithDefaultTag("1.0.0-dev"),
+		WithExtraTags("latest", "1.0.0-amd64"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, path.Join("some/namespace", "new-components/scanners/some-component/helper"), cr.Repo())
+	assert.Equal(t, v1.ComponentTypeScanner, cr.Type())
+	assert.Equal(t, "some-component/helper", cr.Name())
+	assert.Equal(t, "1.0.0-dev", cr.Tag())
+	assert.Equal(t, "new-components/scanners/some-component/helper", cr.Directory())
+	assert.Equal(t, "kind-registry:5000", cr.Registry())
+	assert.Equal(t, path.Join("kind-registry:5000", "some/namespace", "new-components/scanners/some-component/helper:1.0.0-dev"), cr.URL())
+	assert.ElementsMatch(t,
+		[]string{
+			path.Join("kind-registry:5000", "some/namespace", "new-components/scanners/some-component/helper:1.0.0-dev"),
+			path.Join("kind-registry:5000", "some/namespace", "new-components/scanners/some-component/helper:1.0.0-amd64"),
+			path.Join("kind-registry:5000", "some/namespace", "new-components/scanners/some-component/helper:latest"),
+		},
+		cr.URLs(),
+	)
 }


### PR DESCRIPTION
eg, if a component in `components/scanners/bla` has a helper image it can declare it in the `components/scanners/bla/helper` directory and the builder will build it using the same algorithm as when building a normal component image, meaning it will check if there is a Makefile with an `image` target, otherwise it will use a base Dockerfile for it.