### PR TITLE
Fix components serialisation/deserialisation + adding ability for gRPC remote client to retry

### DIFF
--- a/pkg/types/v1/parameter.go
+++ b/pkg/types/v1/parameter.go
@@ -35,7 +35,7 @@ type (
 		Name string `json:"name" yaml:"name"`
 		// Type is the parameter type.
 		Type ParameterType `json:"type" yaml:"type"`
-		// Value is the JSON encoded/decoded value of the parameter which is decoded based its Type.
+		// Value is the JSON/Yaml encoded/decoded value of the parameter which is decoded based its Type.
 		Value any `json:"value,omitempty" yaml:"value,omitempty"`
 	}
 )
@@ -46,9 +46,9 @@ func (p *Parameter) MarshalYAML() (interface{}, error) {
 	}
 
 	b, err := yaml.Marshal(struct {
-		Name  string
-		Type  ParameterType
-		Value any
+		Name  string        `yaml:"name"`
+		Type  ParameterType `yaml:"type"`
+		Value any           `yaml:"value,omitempty"`
 	}{
 		Name:  p.Name,
 		Type:  p.Type,
@@ -68,8 +68,8 @@ func (p *Parameter) UnmarshalYAML(value *yaml.Node) error {
 
 	var (
 		partialParameter = &struct {
-			Name string
-			Type ParameterType
+			Name string        `yaml:"name"`
+			Type ParameterType `yaml:"type"`
 		}{}
 	)
 
@@ -83,13 +83,17 @@ func (p *Parameter) UnmarshalYAML(value *yaml.Node) error {
 
 	switch partialParameter.Type {
 	case ParameterTypeString, ParameterTypeConstString:
-		strPtr := struct{ Value *string }{}
+		strPtr := struct {
+			Value *string `yaml:"value"`
+		}{}
 		if err := value.Decode(&strPtr); err != nil {
 			return errors.Errorf("failed to unmarshal parameter %s: %w", p.Name, err)
 		}
 		p.Value = strPtr.Value
 	case ParameterTypeListString:
-		parameterValue := struct{ Value []string }{}
+		parameterValue := struct {
+			Value []string `yaml:"value"`
+		}{}
 		err = value.Decode(&parameterValue)
 		p.Value = parameterValue.Value
 	default:
@@ -105,8 +109,8 @@ func (p *Parameter) UnmarshalYAML(value *yaml.Node) error {
 // UnmarshalJSON unmarshal JSON bytes into a Parameter object.
 func (p *Parameter) UnmarshalJSON(b []byte) error {
 	partialParameter := &struct {
-		Name string
-		Type ParameterType
+		Name string        `json:"name"`
+		Type ParameterType `json:"type"`
 	}{}
 
 	var err error
@@ -119,13 +123,17 @@ func (p *Parameter) UnmarshalJSON(b []byte) error {
 
 	switch partialParameter.Type {
 	case ParameterTypeString, ParameterTypeConstString:
-		strPtr := struct{ Value *string }{}
+		strPtr := struct {
+			Value *string `json:"value"`
+		}{}
 		if err = json.Unmarshal(b, &strPtr); err != nil {
 			return errors.Errorf("failed to unmarshal parameter %s: %w", p.Name, err)
 		}
 		p.Value = strPtr.Value
 	case ParameterTypeListString:
-		parameterValue := &struct{ Value []string }{}
+		parameterValue := &struct {
+			Value []string `json:"value"`
+		}{}
 		err = json.Unmarshal(b, parameterValue)
 		p.Value = parameterValue.Value
 	default:
@@ -145,9 +153,9 @@ func (p *Parameter) MarshalJSON() ([]byte, error) {
 	}
 
 	b, err := json.Marshal(struct {
-		Name  string
-		Type  ParameterType
-		Value any
+		Name  string        `json:"name"`
+		Type  ParameterType `json:"type"`
+		Value any           `json:"value"`
 	}{
 		Name:  p.Name,
 		Type:  p.Type,

--- a/sdk/component/store/remote/findings-client/README.md
+++ b/sdk/component/store/remote/findings-client/README.md
@@ -4,6 +4,10 @@ This implementation of `component.Storer` interacts with a findings client via G
 
 ## Configuration
 
-| Environment Variable                | Type   | Required | Default                  | Possible Values          |
-|-------------------------------------|--------|----------|--------------------------|--------------------------|
-| SMITHY\_REMOTE\_STORE\_FINDINGS\_SERVICE\_ADDR    | string | no       | localhost:50051                        | -                        |
+| Environment Variable                | Type                | Required | Default         | Possible Values          |
+|-------------------------------------|---------------------|----------|-----------------|--------------------------|
+| SMITHY\_REMOTE\_STORE\_FINDINGS\_SERVICE\_ADDR    | string              | no       | localhost:50051 | -                        |
+| SMITHY\_REMOTE\_CLIENT\_MAX\_ATTEMPTS    | int                 | no       | 10              | -                        |
+| SMITHY\_REMOTE\_CLIENT\_INITIAL\_BACKOFF\_SECONDS    | duration in seconds | no       | 5s              | -                        |
+| SMITHY\_REMOTE\_CLIENT\_MAX\_BACKOFF\_SECONDS    | duration in seconds | no       | 60s             | -                        |
+| SMITHY\_REMOTE\_CLIENT\_BACKOFF\_MULTIPLIER    | float               | no       | 1.5             | -                        |

--- a/sdk/component/store/remote/findings-client/client.go
+++ b/sdk/component/store/remote/findings-client/client.go
@@ -2,6 +2,7 @@ package findingsclient
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-errors/errors"
 	"github.com/smithy-security/pkg/env"
@@ -17,10 +18,40 @@ import (
 	ocsf "github.com/smithy-security/smithy/sdk/gen/ocsf_schema/v1"
 )
 
-type client struct {
-	rpcConn           *grpc.ClientConn
-	findingsSvcClient v1.FindingsServiceClient
-}
+const (
+	defaultClientMaxAttempts           = 10
+	defaultClientInitialBackoffSeconds = "5s"
+	defaultClientMaxBackoffSeconds     = "60s"
+	defaultClientBackoffMultiplier     = 1.5
+)
+
+type (
+	client struct {
+		rpcConn           *grpc.ClientConn
+		findingsSvcClient v1.FindingsServiceClient
+	}
+
+	clientRetry struct {
+		MethodConfig []clientMethodConf `json:"methodConfig"`
+	}
+
+	clientMethodConf struct {
+		Name        []clientRetryMethod `json:"name"`
+		RetryPolicy clientRetryPolicy   `json:"retryPolicy"`
+	}
+
+	clientRetryMethod struct {
+		Service string `json:"service"`
+	}
+
+	clientRetryPolicy struct {
+		MaxAttempts          int      `json:"maxAttempts"`
+		InitialBackoff       string   `json:"initialBackoff"`
+		MaxBackoff           string   `json:"maxBackoff"`
+		BackoffMultiplier    float64  `json:"backoffMultiplier"`
+		RetryableStatusCodes []string `json:"retryableStatusCodes"`
+	}
+)
 
 // New it returns a new findings' client.
 func New() (*client, error) {
@@ -33,9 +64,15 @@ func New() (*client, error) {
 		return nil, err
 	}
 
+	retryStr, err := newClientRetryStr()
+	if err != nil {
+		return nil, err
+	}
+
 	conn, err := grpc.NewClient(
 		findingsSvcAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(retryStr),
 	)
 	if err != nil {
 		return nil, errors.Errorf("could not create findings client connection: %v", err)
@@ -45,6 +82,73 @@ func New() (*client, error) {
 		rpcConn:           conn,
 		findingsSvcClient: v1.NewFindingsServiceClient(conn),
 	}, nil
+}
+
+// newClientRetryStr returns gRPC retry config per https://grpc.io/docs/guides/retry/.
+func newClientRetryStr() (string, error) {
+	clientMaxAttempts, err := env.GetOrDefault(
+		"SMITHY_REMOTE_CLIENT_MAX_ATTEMPTS",
+		defaultClientMaxAttempts,
+		env.WithDefaultOnError(true),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	clientInitialBackoffSeconds, err := env.GetOrDefault(
+		"SMITHY_REMOTE_CLIENT_INITIAL_BACKOFF_SECONDS",
+		defaultClientInitialBackoffSeconds,
+		env.WithDefaultOnError(true),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	clientMaxBackoffSeconds, err := env.GetOrDefault(
+		"SMITHY_REMOTE_CLIENT_MAX_BACKOFF_SECONDS",
+		defaultClientMaxBackoffSeconds,
+		env.WithDefaultOnError(true),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	clientBackoffMultiplier, err := env.GetOrDefault(
+		"SMITHY_REMOTE_CLIENT_BACKOFF_MULTIPLIER",
+		defaultClientBackoffMultiplier,
+		env.WithDefaultOnError(true),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	var retry = clientRetry{
+		MethodConfig: []clientMethodConf{
+			{
+				Name: []clientRetryMethod{
+					{
+						Service: "findings_service.v1.FindingsService",
+					},
+				},
+				RetryPolicy: clientRetryPolicy{
+					MaxAttempts:       clientMaxAttempts,
+					InitialBackoff:    clientInitialBackoffSeconds,
+					MaxBackoff:        clientMaxBackoffSeconds,
+					BackoffMultiplier: clientBackoffMultiplier,
+					RetryableStatusCodes: []string{
+						"UNAVAILABLE",
+					},
+				},
+			},
+		},
+	}
+
+	srvRetryBytes, err := json.Marshal(retry)
+	if err != nil {
+		return "", errors.Errorf("failed to marshal default client retry conf: %w", err)
+	}
+
+	return string(srvRetryBytes), nil
 }
 
 // Close closes the underlying connection to the findings' client.


### PR DESCRIPTION
The first bit fixes an issue that we have with parsing components across the codebases.

The second bit helps us with avoiding issues when running the remote sidecar.