### PR TITLE
Use default temp directory instead of hardcoded `/tmp`

### DIFF
--- a/components/enrichers/aggregator/main_test.go
+++ b/components/enrichers/aggregator/main_test.go
@@ -107,10 +107,10 @@ func createObjects(toolRuns, issuesInEach, annotationsEach int) ([]*v1.EnrichedL
 
 func TestSignIssues(t *testing.T) {
 	// prepare
-	indir, err := os.MkdirTemp("/tmp", "")
+	indir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	outdir, err := os.MkdirTemp("/tmp", "")
+	outdir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	toolRuns := 1
@@ -169,10 +169,10 @@ func TestSignIssues(t *testing.T) {
 
 func TestAggregateIssues(t *testing.T) {
 	// prepare
-	indir, err := os.MkdirTemp("/tmp", "")
+	indir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	outdir, err := os.MkdirTemp("/tmp", "")
+	outdir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	toolRuns := 3
@@ -221,10 +221,10 @@ func TestAggregateIssues(t *testing.T) {
 
 func TestAggregateIssuesHandlesNoIssues(t *testing.T) {
 	// prepare
-	indir, err := os.MkdirTemp("/tmp", "")
+	indir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	outdir, err := os.MkdirTemp("/tmp", "")
+	outdir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	// Create mock input data

--- a/components/enrichers/depsdev/main_test.go
+++ b/components/enrichers/depsdev/main_test.go
@@ -51,7 +51,7 @@ func genSampleIssues(t *testing.T) []*v1.Issue {
 
 func prepareIssue(t *testing.T, produceEmptyIssues bool) string {
 	// prepare
-	dir, err := os.MkdirTemp("/tmp", "")
+	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	var rawIssues []*v1.Issue

--- a/components/enrichers/enricher_test.go
+++ b/components/enrichers/enricher_test.go
@@ -169,7 +169,7 @@ func TestParseFlags(t *testing.T) {
 
 func TestWriteData(t *testing.T) {
 	enricherName := "tests-enricher"
-	workdir, err := os.MkdirTemp("/tmp", "")
+	workdir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	require.NoError(t, os.Mkdir(filepath.Join(workdir, "raw"), 0755))
 

--- a/components/enrichers/test_utils.go
+++ b/components/enrichers/test_utils.go
@@ -11,10 +11,10 @@ import (
 
 // SetupIODirs creates temporary directories for input and output files
 func SetupIODirs(t *testing.T) (indir, outdir string) {
-	indir, err := os.MkdirTemp("/tmp", "")
+	indir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	outdir, err = os.MkdirTemp("/tmp", "")
+	outdir, err = os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	return indir, outdir

--- a/components/producers/aggregator/main_test.go
+++ b/components/producers/aggregator/main_test.go
@@ -36,7 +36,7 @@ func genSampleIssues() []*v1.Issue {
 
 func TestParseIssues(t *testing.T) {
 	// prepare
-	dir, err := os.MkdirTemp("/tmp", "")
+	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	issues := genSampleIssues()

--- a/components/sources/dependency/main_test.go
+++ b/components/sources/dependency/main_test.go
@@ -30,7 +30,7 @@ func assertFilesContents(t *testing.T, fileNamesToContents map[string]string, di
 }
 
 func TestGoPURL(t *testing.T) {
-	out, err := os.MkdirTemp("/tmp", "")
+	out, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func TestGoPURL(t *testing.T) {
 }
 
 func TestNPMPURL(t *testing.T) {
-	out, err := os.MkdirTemp("/tmp", "")
+	out, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestNPMPURL(t *testing.T) {
 }
 
 func TestPyPiPurl(t *testing.T) {
-	out, err := os.MkdirTemp("/tmp", "")
+	out, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/components/package.go
+++ b/pkg/components/package.go
@@ -39,7 +39,7 @@ func Package(ctx context.Context, name, componentFolder string, smithyVersion st
 		return errors.Errorf("%s: path is not a directory", componentFolder)
 	}
 
-	tempFolder, err := os.MkdirTemp("/tmp", "smithy-helm")
+	tempFolder, err := os.MkdirTemp("", "smithy-helm")
 	if err != nil {
 		return errors.Errorf("there was an error while trying to create temp directory: %w", err)
 	}


### PR DESCRIPTION
This is mostly relevant for component packaging, as `/tmp` does not exist on Windows, preventing the poor souls having to work with that OS from running `smithyctl component package`.

Made the same change in other locations for consistency.