### PR TITLE
Trigger repackaging after packaging components.

### DIFF
--- a/.github/workflows/package-component.yaml
+++ b/.github/workflows/package-component.yaml
@@ -27,6 +27,7 @@ jobs:
           echo "component_type=$COMPONENT_TYPE" >> $GITHUB_OUTPUT
           echo "component_name=$COMPONENT_NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Extract SDK Version
         id: sdk_version
@@ -63,3 +64,15 @@ jobs:
                 --sdk-version=${{ steps.sdk_version.outputs.sdk_version }} \
                 --spec-path=new-components/${{ steps.tag_info.outputs.component_type }}/${{ steps.tag_info.outputs.component_name }}/component.yaml \
                 --version=${{ steps.tag_info.outputs.version }}
+
+      - name: Trigger repackaging event in SAAS
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: smithy-security/saas
+          event-type: package_published
+          client-payload: |- 
+            {
+              "repo_name": "${{ github.repository }}", 
+              "component_tag": "${{ steps.tag_info.outputs.tag }}"
+            }


### PR DESCRIPTION
Uses [repository-dispatch](https://github.com/peter-evans/repository-dispatch) to trigger a "repackaging" action in SAAS after publishing a component package.

SAAS is already configured to handle this:

```yaml
...
on:
  repository_dispatch:
    types: [package_published]
    
...

jobs:
  package:
    runs-on: ubuntu-latest
    steps:
      - name: Process new package
        id: process_new_package
        run: |
          REPO_NAME=${{ github.event.client_payload.repo_name }}
          COMPONENT_TAG=${{ github.event.client_payload.component_tag }}
```