### PR TITLE
Enrichers, Filters and Reporters shouldn't error when no findings were found

### DIFF
--- a/sdk/component/enricher.go
+++ b/sdk/component/enricher.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/go-errors/errors"
+
+	"github.com/smithy-security/smithy/sdk/component/store"
 )
 
 // RunEnricher runs an enricher after initialising the run context.
@@ -14,11 +16,11 @@ func RunEnricher(ctx context.Context, enricher Enricher, opts ...RunnerOption) e
 			var (
 				instanceID = cfg.InstanceID
 				logger     = LoggerFromContext(ctx).With(logKeyComponentType, "enricher")
-				store      = cfg.StoreConfig.Storer
+				storer     = cfg.StoreConfig.Storer
 			)
 
 			defer func() {
-				if err := store.Close(ctx); err != nil {
+				if err := storer.Close(ctx); err != nil {
 					logger.With(logKeyError, err.Error()).Error("closing step failed, ignoring...")
 				}
 			}()
@@ -26,10 +28,19 @@ func RunEnricher(ctx context.Context, enricher Enricher, opts ...RunnerOption) e
 			logger.Debug("preparing to execute enricher component...")
 			logger.Debug("preparing to execute read step...")
 
-			findings, err := store.Read(ctx, instanceID)
+			findings, err := storer.Read(ctx, instanceID)
 			if err != nil {
+				if errors.Is(err, store.ErrNoFindingsFound) {
+					logger.Debug("no findings found, skipping enrichment step...")
+					return nil
+				}
 				logger.With(logKeyError, err.Error()).Error("reading step failed")
 				return errors.Errorf("could not read: %w", err)
+			}
+
+			if len(findings) == 0 {
+				logger.Debug("no findings found, skipping enrichment step...")
+				return nil
 			}
 
 			logger = logger.With(logKeyNumParsedFindings, len(findings))
@@ -46,7 +57,7 @@ func RunEnricher(ctx context.Context, enricher Enricher, opts ...RunnerOption) e
 			logger.Debug("enricher step completed!")
 			logger.Debug("preparing to execute update step...")
 
-			if err := store.Update(ctx, instanceID, enrichedFindings); err != nil {
+			if err := storer.Update(ctx, instanceID, enrichedFindings); err != nil {
 				logger.With(logKeyError, err.Error()).Error("updating step failed")
 				return errors.Errorf("could not update: %w", err)
 			}

--- a/sdk/component/filter.go
+++ b/sdk/component/filter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/go-errors/errors"
+
+	"github.com/smithy-security/smithy/sdk/component/store"
 )
 
 // RunFilter runs a filter after initialising the run context.
@@ -14,11 +16,11 @@ func RunFilter(ctx context.Context, filter Filter, opts ...RunnerOption) error {
 			var (
 				instanceID = cfg.InstanceID
 				logger     = LoggerFromContext(ctx).With(logKeyComponentType, "filter")
-				store      = cfg.StoreConfig.Storer
+				storer     = cfg.StoreConfig.Storer
 			)
 
 			defer func() {
-				if err := store.Close(ctx); err != nil {
+				if err := storer.Close(ctx); err != nil {
 					logger.With(logKeyError, err.Error()).Error("closing step failed, ignoring...")
 				}
 			}()
@@ -26,10 +28,19 @@ func RunFilter(ctx context.Context, filter Filter, opts ...RunnerOption) error {
 			logger.Debug("preparing to execute filter component...")
 			logger.Debug("preparing to execute read step...")
 
-			findings, err := store.Read(ctx, instanceID)
+			findings, err := storer.Read(ctx, instanceID)
 			if err != nil {
+				if errors.Is(err, store.ErrNoFindingsFound) {
+					logger.Debug("no findings found, skipping filter step...")
+					return nil
+				}
 				logger.With(logKeyError, err.Error()).Error("reading step failed")
 				return errors.Errorf("could not read: %w", err)
+			}
+
+			if len(findings) == 0 {
+				logger.Debug("no findings found, skipping filter step...")
+				return nil
 			}
 
 			logger = logger.With(logKeyNumParsedFindings, len(findings))
@@ -50,7 +61,7 @@ func RunFilter(ctx context.Context, filter Filter, opts ...RunnerOption) error {
 			logger.Debug("filter step completed!")
 			logger.Debug("preparing to execute update step...")
 
-			if err := store.Update(ctx, instanceID, filteredFindings); err != nil {
+			if err := storer.Update(ctx, instanceID, filteredFindings); err != nil {
 				logger.With(logKeyError, err.Error()).Error("updating step failed")
 				return errors.Errorf("could not update: %w", err)
 			}

--- a/sdk/component/scanner.go
+++ b/sdk/component/scanner.go
@@ -27,11 +27,15 @@ func RunScanner(ctx context.Context, scanner Scanner, opts ...RunnerOption) erro
 			logger.Debug("preparing to execute transform step...")
 
 			rawFindings, err := scanner.Transform(ctx)
-			if err != nil {
+			switch {
+			case err != nil:
 				logger.
 					With(logKeyError, err.Error()).
 					Debug("could not execute transform step")
 				return errors.Errorf("could not transform raw findings: %w", err)
+			case len(rawFindings) == 0:
+				logger.Debug("no raw findings found, skipping persisting step...")
+				return nil
 			}
 
 			logger = logger.

--- a/sdk/component/scanner_test.go
+++ b/sdk/component/scanner_test.go
@@ -127,6 +127,21 @@ func TestRunScanner(t *testing.T) {
 		require.ErrorIs(t, runScannerHelper(t, ctx, instanceID, mockScanner, mockStore), errTransform)
 	})
 
+	t.Run("it should return early when no findings were found", func(t *testing.T) {
+		gomock.InOrder(
+			mockScanner.
+				EXPECT().
+				Transform(mockCtx).
+				Return(make([]*ocsf.VulnerabilityFinding, 0), nil),
+			mockStore.
+				EXPECT().
+				Close(mockCtx).
+				Return(nil),
+		)
+
+		require.NoError(t, runScannerHelper(t, ctx, instanceID, mockScanner, mockStore))
+	})
+
 	t.Run("it should return early when validation errors", func(t *testing.T) {
 		var errValidate = errors.New("validate-is-sad")
 

--- a/sdk/component/store/remote/findings-client/client.go
+++ b/sdk/component/store/remote/findings-client/client.go
@@ -172,6 +172,13 @@ func (c *client) Read(ctx context.Context, instanceID uuid.UUID) ([]*vf.Vulnerab
 		return nil, errors.Errorf("could not get findings: %w", c.checkErr(err))
 	}
 
+	switch {
+	case resp == nil:
+		return nil, errors.New("unexpected nil response")
+	case len(resp.Findings) == 0:
+		return nil, store.ErrNoFindingsFound
+	}
+
 	findings := make([]*vf.VulnerabilityFinding, 0, len(resp.Findings))
 	for _, finding := range resp.Findings {
 		findings = append(


### PR DESCRIPTION
- Skip running component steps when no findings are found for: enrichers, filters and reporters.
- Also avoid persisting findings during scanning if non are found.
- Return no findings found error also in the gRPC client as we do in the other storages