### PR TITLE
Track sdk version

### DIFF
--- a/new-components/Dockerfile
+++ b/new-components/Dockerfile
@@ -17,7 +17,12 @@ RUN CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-all" \
     # Makes memory exploitation harder.
     # Add a small overhead at compile time.
     GOFLAGS="-buildmode=pie" \
-      go build -ldflags "-s -w" -trimpath -o app ${COMPONENT_BINARY_SOURCE_PATH}
+      go build \
+        -ldflags "-X github.com/smithy-security/smithy/sdk.Version=${SDK_VERSION} -s -w" \
+        -trimpath \
+        -o \
+        app \
+        ${COMPONENT_BINARY_SOURCE_PATH}
 
 # Create a workspace to clone repos to.
 RUN mkdir -p /workspace

--- a/new-components/targets/git-clone/Makefile
+++ b/new-components/targets/git-clone/Makefile
@@ -4,6 +4,7 @@ BUILD_ARCHITECTURE=
 COMPONENT_REGISTRY=localhost:5000
 COMPONENT_REPOSITORY=smithy-security/smithy/components/targets/git-clone
 COMPONENT_TAG=latest
+SDK_VERSION=unset
 
 run:
 	docker-compose up --build --force-recreate --remove-orphans gitea target
@@ -23,7 +24,7 @@ build-target:
 	# Makes memory exploitation harder.
     # Add a small overhead at compile time.
 	GOFLAGS="-buildmode=pie" \
-		go build -ldflags "-s -w" -trimpath -o target ./cmd/git-clone/main.go
+		go build -ldflags "-X github.com/smithy-security/smithy/sdk.Version=$(SDK_VERSION) -s -w" -trimpath -o target ./cmd/git-clone/main.go
 
 image:
 	docker build $$([ "${BUILD_ARCHITECTURE}" != "" ] && echo "--platform=${BUILD_ARCHITECTURE}" ) \

--- a/new-components/targets/git-clone/dockerfiles/git-clone/Dockerfile
+++ b/new-components/targets/git-clone/dockerfiles/git-clone/Dockerfile
@@ -1,6 +1,7 @@
 # Used only to build Go binaries.
 FROM golang:1.23.3 AS builder
 
+ARG SDK_VERSION=unset
 WORKDIR /wrk
 
 # Copy only go related files.

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,3 +1,5 @@
 package sdk
 
-const Version = "0.0.3-alpha"
+// Version is the SDK's version which is overridable at build time with:
+// go build -ldflags "-X github.com/smithy-security/smithy/sdk.Version=1.2.3"
+var Version = "development"

--- a/smithyctl/README.md
+++ b/smithyctl/README.md
@@ -41,6 +41,6 @@ smithyctl version
 
 ## Development
 
-Compile `smithyctl` locally by running `make smithyctl/cmd/bin` in the root of this project.
+Compile `smithyctl` locally by running `make smithyctl/bin` in the root of this project.
 
 You can then find the binary in `./bin/smithyctl/cmd/{GOOS}/{GOARCH}/smithyctl`.

--- a/smithyctl/command/component/build.go
+++ b/smithyctl/command/component/build.go
@@ -30,6 +30,7 @@ type (
 		push                    bool
 		platform                string
 		tags                    []string
+		sdkVersion              string
 	}
 )
 
@@ -118,6 +119,14 @@ func NewBuildCommand() *cobra.Command {
 			[]string{images.DefaultTag},
 			"tags to use for images, can be multiple",
 		)
+	cmd.
+		Flags().
+		StringVar(
+			&buildCmdFlags.sdkVersion,
+			"sdk-version",
+			"",
+			"sdk-version passed to build components",
+		)
 
 	return cmd
 }
@@ -185,6 +194,10 @@ func buildComponent(ctx context.Context, flags buildFlags, componentPath string)
 
 	if flags.username != "" {
 		buildOpts = append(buildOpts, dockerimages.WithUsernamePassword(flags.username, flags.password))
+	}
+
+	if flags.sdkVersion != "" {
+		buildOpts = append(buildOpts, dockerimages.WithSDKVersion(flags.sdkVersion))
 	}
 
 	dockerClient, err := dockerclient.NewClientWithOpts(

--- a/smithyctl/docs/component/BUILD.md
+++ b/smithyctl/docs/component/BUILD.md
@@ -8,17 +8,18 @@ smithyctl component build
 
 ## Flags
 
-| Flag                   | Description                                                                     | Default                   |
-|------------------------|---------------------------------------------------------------------------------|---------------------------|
-| `registry`              | registry to use for the images                                                  | ghcr.io                   |
-| `namespace`              | namespace that will be added to all the images built by the system              | smithy-security/smithy    |
-| `base-component-dockerfile`              | base Dockerfile to use to build all the images                                  | new-components/Dockerfile |
-| `registry-auth-username`              | username to authenticate with for the image registry                            | -                         |
-| `registry-auth-password`              | password to authenticate with for the image registry                            | -                         |
-| `label`              | labels to be added to the image                                                 | -                         |
-| `push`              | push images once they are built                                                 | false                     |
-| `platform`              | build an image for a platform other than one where the Docker server is running |                           |
-| `tag`              | tags to use for images, can be multiple                                         | latest                    |
+| Flag                        | Description                                                                     | Default                   |
+|-----------------------------|---------------------------------------------------------------------------------|---------------------------|
+| `registry`                  | registry to use for the images                                                  | ghcr.io                   |
+| `namespace`                 | namespace that will be added to all the images built by the system              | smithy-security/smithy    |
+| `base-component-dockerfile` | base Dockerfile to use to build all the images                                  | new-components/Dockerfile |
+| `registry-auth-username`    | username to authenticate with for the image registry                            | -                         |
+| `registry-auth-password`    | password to authenticate with for the image registry                            | -                         |
+| `label`                     | labels to be added to the image                                                 | -                         |
+| `push`                      | push images once they are built                                                 | false                     |
+| `platform`                  | build an image for a platform other than one where the Docker server is running |                           |
+| `tag`                       | tags to use for images, can be multiple                                         | latest                    |
+| `sdk-version`               | sets the component sdk-version used for observability                           | unset                     |
 
 ## Example
 

--- a/smithyctl/internal/images/component.go
+++ b/smithyctl/internal/images/component.go
@@ -73,7 +73,7 @@ func WithDefaultTag(t string) ResolutionOptionFn {
 	}
 }
 
-// WithDefaultTag changes the tag that will be set by default to all the
+// WithExtraTags changes the tag that will be set by default to all the
 // component images
 func WithExtraTags(tags ...string) ResolutionOptionFn {
 	return func(o *resolutionOptions) error {

--- a/smithyctl/internal/images/docker/builder.go
+++ b/smithyctl/internal/images/docker/builder.go
@@ -31,6 +31,7 @@ type builderOptions struct {
 	push               bool
 	username, password string
 	labels             map[string]string
+	sdkVersion         string
 }
 
 // BuilderOptionFn is used to modify the options passed to the builder
@@ -76,6 +77,13 @@ func WithUsernamePassword(username, password string) BuilderOptionFn {
 	}
 }
 
+// WithSDKVersion customises the sdk version.
+func WithSDKVersion(version string) BuilderOptionFn {
+	return func(o *builderOptions) {
+		o.sdkVersion = version
+	}
+}
+
 func makeOptions(ctx context.Context, daemon dockerBuilder, opts ...BuilderOptionFn) (builderOptions, error) {
 	daemonVersion, err := daemon.ServerVersion(ctx)
 	if err != nil {
@@ -89,6 +97,7 @@ func makeOptions(ctx context.Context, daemon dockerBuilder, opts ...BuilderOptio
 		labels:             images.DefaultLabels,
 		baseDockerfilePath: "./new-components/Dockerfile",
 		platform:           daemonVersion.Os + "/" + daemonVersion.Arch,
+		sdkVersion:         "unset",
 	}
 
 	for _, opt := range opts {
@@ -198,6 +207,7 @@ func (b *Builder) Build(ctx context.Context, cr *images.ComponentRepository) (st
 			Tags: cr.URLs(),
 			BuildArgs: map[string]*string{
 				"COMPONENT_PATH": &componentDirectory,
+				"SDK_VERSION":    &b.opts.sdkVersion,
 			},
 			PullParent: true,
 			Platform:   b.opts.platform,

--- a/smithyctl/internal/images/docker/builder_test.go
+++ b/smithyctl/internal/images/docker/builder_test.go
@@ -43,6 +43,7 @@ func TestBuilder(t *testing.T) {
 		tarReadCloser := io.NopCloser(strings.NewReader("bla"))
 
 		componentDirectory := "testdata/scanners/gosec"
+		sdkVersion := "1.0.0"
 
 		gomock.InOrder(
 			dockerBuilderMock.
@@ -67,6 +68,7 @@ func TestBuilder(t *testing.T) {
 						Platform:   "minix/x68",
 						BuildArgs: map[string]*string{
 							"COMPONENT_PATH": &componentDirectory,
+							"SDK_VERSION":    &sdkVersion,
 						},
 						Labels:     images.DefaultLabels,
 						Dockerfile: "testdata/Dockerfile",
@@ -86,6 +88,7 @@ func TestBuilder(t *testing.T) {
 			dockerBuilderMock,
 			"components/scanners/test/component.yaml",
 			WithBaseDockerfilePath("testdata/Dockerfile"),
+			WithSDKVersion("1.0.0"),
 		)
 		require.NoError(t, err)
 
@@ -115,6 +118,7 @@ func TestBuilder(t *testing.T) {
 		tarReadCloser := io.NopCloser(strings.NewReader("bla"))
 
 		componentDirectory := "testdata/scanners/gosec"
+		sdkVersion := "unset"
 
 		gomock.InOrder(
 			dockerBuilderMock.
@@ -139,6 +143,7 @@ func TestBuilder(t *testing.T) {
 						Platform:   "minix/x68",
 						BuildArgs: map[string]*string{
 							"COMPONENT_PATH": &componentDirectory,
+							"SDK_VERSION":    &sdkVersion,
 						},
 						Labels:     images.DefaultLabels,
 						Dockerfile: "testdata/Dockerfile",
@@ -188,6 +193,7 @@ func TestBuilder(t *testing.T) {
 		pushReadCloser := io.NopCloser(strings.NewReader("{\"status\":\"Layer already exists\",\"progressDetail\":{},\"id\":\"a80545a98dcd\"}"))
 
 		componentDirectory := "testdata/scanners/gosec"
+		sdkVersion := "unset"
 
 		authConfigBytes, err := json.Marshal(dockerregistrytypes.AuthConfig{
 			Username: "user",
@@ -219,6 +225,7 @@ func TestBuilder(t *testing.T) {
 						Platform:   "minix/x68",
 						BuildArgs: map[string]*string{
 							"COMPONENT_PATH": &componentDirectory,
+							"SDK_VERSION":    &sdkVersion,
 						},
 						Labels:     images.DefaultLabels,
 						Dockerfile: "testdata/Dockerfile",

--- a/smithyctl/internal/images/docker/testdata/Dockerfile
+++ b/smithyctl/internal/images/docker/testdata/Dockerfile
@@ -1,6 +1,7 @@
 # Used only to build Go binaries.
 FROM golang:1.23.3 AS builder
 
+ARG SDK_VERSION=unset
 ARG COMPONENT_PATH=.
 ARG COMPONENT_BINARY_SOURCE_PATH=cmd/main.go
 
@@ -19,7 +20,12 @@ RUN CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-all" \
     GOFLAGS="-buildmode=pie" \
     GOOS="linux" \
     GOARCH="amd64" \
-      go build -ldflags "-s -w" -trimpath -o app ${COMPONENT_BINARY_SOURCE_PATH}
+      go build \
+        -ldflags "-X github.com/smithy-security/smithy/sdk.Version=${SDK_VERSION} -s -w" \
+        -trimpath \
+        -o \
+        app \
+        ${COMPONENT_BINARY_SOURCE_PATH}
 
 # Create a workspace to clone repos to.
 RUN mkdir -p /workspace


### PR DESCRIPTION
- Make SDK version customisable at compile time
- Support `sdk-version` flag on `smithyctl build`
- Injecting the flag into go build flags for base images