### PR TITLE
Bug not handling prs refs

### DIFF
--- a/components/targets/git-clone/component.yaml
+++ b/components/targets/git-clone/component.yaml
@@ -8,11 +8,15 @@ parameters:
   - name: reference
     type: string
     value: main
+  - name: base_reference
+    type: string
+    value: ""
 steps:
   - name: clone-repo
     env_vars:
       GIT_CLONE_REPO_URL: "{{ .parameters.repo_url }}"
       GIT_CLONE_REFERENCE: "{{ .parameters.reference }}"
+      GIT_CLONE_BASE_REFERENCE: "{{ .parameters.base_reference }}"
       GIT_CLONE_PATH: "{{ sourceCodeWorkspace }}"
       GIT_CLONE_TARGET_METADATA_PATH: "{{ targetMetadataWorkspace }}"
       GIT_RAW_DIFF_PATH: "{{ targetMetadataWorkspace }}"

--- a/components/targets/git-clone/internal/target/target.go
+++ b/components/targets/git-clone/internal/target/target.go
@@ -113,7 +113,7 @@ func (g *gitCloneTarget) Prepare(ctx context.Context) error {
 	if err := g.prepareDiff(ctx, repo); err != nil {
 		return errors.Errorf("could not prepare diff: %w", err)
 	}
-	logger.Debug("successfully wrote diff")
+	logger.Debug("successfully wrote diff if needed")
 
 	logger.Debug("git-cloner completed, returning")
 	return nil
@@ -179,12 +179,13 @@ func (g *gitCloneTarget) prepareDiff(ctx context.Context, repo *git.Repository) 
 	logger := component.LoggerFromContext(ctx)
 	logger.Debug("preparing to compute diff...")
 
-	diff, err := repo.GetDiff()
+	diff, err := repo.GetDiff(ctx)
 	switch {
 	case err != nil:
 		return errors.Errorf("could not get repository diff: %w", err)
 	case diff == "":
 		logger.Debug("no diff found, skipping writing raw diff")
+		return nil
 	}
 
 	logger.Debug("computed diff", slog.String("raw_diff", diff))

--- a/components/targets/git-clone/pkg/git/conf.go
+++ b/components/targets/git-clone/pkg/git/conf.go
@@ -12,6 +12,7 @@ type (
 	Conf struct {
 		RepoURL            string
 		Reference          string
+		BaseRef            string
 		ClonePath          string
 		TargetMetadataPath string
 		RawDiffPath        string
@@ -34,7 +35,12 @@ func NewConf() (*Conf, error) {
 		return nil, err
 	}
 
-	reference, err := env.GetOrDefault("GIT_CLONE_REFERENCE", "")
+	reference, err := env.GetOrDefault("GIT_CLONE_REFERENCE", "", env.WithDefaultOnError(true))
+	if err != nil {
+		return nil, err
+	}
+
+	baseRef, err := env.GetOrDefault("GIT_CLONE_BASE_REFERENCE", "")
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +102,7 @@ func NewConf() (*Conf, error) {
 	return &Conf{
 		RepoURL:            repoURL,
 		Reference:          reference,
+		BaseRef:            baseRef,
 		ClonePath:          clonePath,
 		TargetMetadataPath: targetMetadataPath,
 		RawDiffPath:        rawDiffOutPath,


### PR DESCRIPTION
Fixes an issue when cloning from a pull request ref https://plexor.saas.smithy.security/runs/68466b18-36b8-44e0-9fc2-e840d34b82cd.

Reverts some changes to the clone and does more heavy lifting in the Diff getter business logic where we try to resolve against an optional Base Reference or try out best with main/master.

If the reference is a base branch, the diff is skipped.