### PR TITLE
Add missing LINEAR_BASE_URL env var to conf and also handle the default.

### DIFF
--- a/components/reporters/linear/component.yaml
+++ b/components/reporters/linear/component.yaml
@@ -11,11 +11,15 @@ parameters:
   - name: "issue_labels"
     type: "string"
     value: ""
+  - name: "base_url"
+    type: "string"
+    value: "https://api.linear.app/graphql"
 steps:
   - name: create-issues
     env_vars:
       LINEAR_TEAM_ID: "{{ .parameters.team_id }}"
       LINEAR_API_KEY: "{{ .parameters.api_key }}"
       LINEAR_LABEL_NAMES: "{{ .parameters.issue_labels }}"
+      LINEAR_BASE_URL: "{{ .parameters.base_url }}"
     image: components/reporters/linear
     executable: /bin/app

--- a/components/reporters/linear/internal/config/config.go
+++ b/components/reporters/linear/internal/config/config.go
@@ -46,7 +46,7 @@ func New() (Config, error) {
 		}
 	}
 
-	linearBaseURL, err := env.GetOrDefault("LINEAR_BASE_URL", "")
+	linearBaseURL, err := env.GetOrDefault("LINEAR_BASE_URL", "https://api.linear.app/graphql", env.WithDefaultOnError(true))
 	if err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to get env var LINEAR_BASE_URL: %w", err))
 	}


### PR DESCRIPTION
Fixes `unexpected error: failed to create linear client: invalid config: invalid empty base url`