### PR TITLE
Bump go to 1.24 in custom Dockerfiles.

### DIFF
--- a/components/enrichers/reachability/cdxgen-atom-runner/Dockerfile
+++ b/components/enrichers/reachability/cdxgen-atom-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bookworm AS build
+FROM golang:1.24-bookworm AS build
 
 WORKDIR /build
 

--- a/components/scanners/codeql/codeql-image/Dockerfile
+++ b/components/scanners/codeql/codeql-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bookworm AS build
+FROM golang:1.24-bookworm AS build
 
 WORKDIR /build
 


### PR DESCRIPTION
Fixes codeql and cdxgen build errors when packaging.