### PR TITLE
Defaulting branch for git-cloner to master for test go-dvwa

### DIFF
--- a/components/targets/git-clone/component.yaml
+++ b/components/targets/git-clone/component.yaml
@@ -7,7 +7,7 @@ parameters:
     value: https://github.com/sqreen/go-dvwa.git
   - name: reference
     type: string
-    value: main
+    value: master
   - name: base_reference
     type: string
     value: ""


### PR DESCRIPTION
Mega small QOL improvement to avoid having to overwrite this to get it to work.