### PR TITLE
Updating discord link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Please check the docs over [here](./docs/developing-components/README.md)
 
 ## Contacts
 
-Join our [Discord server](https://discord.gg/xzsHxUxK) to get support and ask questions.
+Join our [Discord server](https://discord.gg/kuNnnVq9) to get support and ask questions.


### PR DESCRIPTION
I've been contacted recently by someone about our Discord link not working.

This invite link:
- is for the #general text channel to our Discord
- doesn't expire