### PR TITLE
Configure Smithyctl's docker client's UsePlainHTTP based on --auth-enabled=true flag

### DIFF
--- a/smithyctl/docs/component/PACKAGING.md
+++ b/smithyctl/docs/component/PACKAGING.md
@@ -21,6 +21,7 @@ smithyctl component package
 | `registry-auth-enabled`  | enables authentication to push artifact to an OCI registry. | `false`                            |
 | `registry-auth-username` | the username for authenticating to the OCI registry.        | `""`                               |
 | `registry-auth-password` | the password for authenticating to the OCI registry.        | `""`                               |
+| `registry-plain-http`    | if true, it enables plain http. Useful for local setups.    | `false`                            |
 | `namespace`              | repository context path                                     | `smithy-security/smithy/manifests` |
 | `sdk-version`            | specifies the sdk version used to package the component.    | `latest`                           |
 | `version`                | is the version used to package the component.               | `latest`                           |


### PR DESCRIPTION
I think that this is a regression that came out when we extended smithyctl's package capabilities.

This fixes an issue where [server gave HTTP response to HTTPS client](https://stackoverflow.com/questions/49674004/docker-repository-server-gave-http-response-to-https-client) when auth is disabled on packaging.

To test it, you can run:
- `make cmd/smithyctl`
- Spin up https://hub.docker.com/_/registry on port 5000
- `bin/../smithyctl component package --registry-url=127.0.0.1:5000 --sdk-version=v1.0.0 --version=v1.0.0 --registry-auth-enabled=false --registry-plain-http=true components/reporters/json-logger/component.yaml`