### PR TITLE
fix: this fixxes a bug where the enricher does not check the logger

### DIFF
--- a/sdk/python/smithy/components/enricher.py
+++ b/sdk/python/smithy/components/enricher.py
@@ -3,6 +3,7 @@ from logging import Logger
 from typing import Optional
 
 from smithy.components.component import Component
+from smithy.helpers.logger import log
 from smithy.remote_store.findings_service.v1 import findings_service_pb2 as pb2
 from smithy.ocsf.ocsf_schema.v1 import ocsf_schema_pb2 as ocsf_pb2
 from smithy.ocsf.ocsf_ext.finding_info.v1 import finding_info_pb2 as ext_pb2
@@ -23,6 +24,7 @@ class Enricher(Component, ABC):
         :param logger: An instance of the Logger class for logging. If not provided, a default logger will be used.
         :type logger: Optional[Logger]
         """
+        logger = logger if logger != None else log
 
         super().__init__(logger)
 


### PR DESCRIPTION
and pushes the logger to the component(parent class) regardless if the logger is none or not. 