### PR TITLE
fix go versions and action caching

### DIFF
--- a/.github/workflows/package-component.yaml
+++ b/.github/workflows/package-component.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: smithyctl/go.mod
+          cache-dependency-path: "**/*.sum"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: "**/*.sum"
 
       - name: Install Go Test Tools
         run: make install-go-test-tools

--- a/Makefile
+++ b/Makefile
@@ -242,3 +242,15 @@ bump-go-dep: $(go_dep_update)
 bump-sdk-version:
 	$(MAKE) bump-go-dep LIB_VERSION=$$(git tag --list --sort="-version:refname" | grep sdk | head -n 1 | sed 's/sdk\///') LIB_URL="github.com/smithy-security/smithy/sdk"
 	@echo "✅✅ Smithy Go SDK version update complete"
+
+component-sdk-version:
+	@if [ -z "$(COMPONENT_DIR)" ]; then \
+		echo "Error: COMPONENT_DIR is not set"; \
+		false; \
+	fi
+
+	@if [ -f  $(COMPONENT_DIR)/go.mod ]; then \
+		grep 'github.com/smithy-security/smithy/sdk' $(COMPONENT_DIR)/go.mod | awk '{print $$2}'; \
+	else \
+		git tag -l | grep sdk | sort -r | head -n 1 | sed 's/sdk\///'; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,8 @@ dep-update-proto: build-buf-container
 ########################################
 ########### RELEASE UTILITIES ##########
 ########################################
-.PHONY: check-branch check-tag-message
+
+.PHONY: check-branch check-tag-message bump-all-patch-tags bump-all-minor-tags bump-all-major-tags
 
 check-branch:
 	@if [ $$(git branch --show-current | tr -d '\n') != "main" ]; \
@@ -192,8 +193,8 @@ bump-all-major-tags: check-branch check-tag-message $(component_major_tags)
 ########################################
 ############## SDK HELPERS #############
 ########################################
-# new targets for components and smithyctl
-.PHONY: smithyctl/bin component-sdk-version bump-sdk-version list-component-tags bump-components
+
+.PHONY: smithyctl/bin check-lib-url check-lib-version bump-go-dep bump-sdk-version
 
 smithyctl/bin:
 	$(eval GOOS:=linux)
@@ -233,11 +234,11 @@ $(go_dep_update): check-lib-url check-lib-version
 		echo "⚠️ component $$(dirname $@) has no dependency on ${LIB_URL}"; \
 	fi
 
+# Bumps a specific dependency to a version for all components that use it
 bump-go-dep: $(go_dep_update)
 	@echo "✅✅ Finished updating ${LIB_URL} to version ${LIB_VERSION} everywhere"	
 
-# Bumps the SDK to a specified version and skips
-# the github.com/smithy-security/smithy/sdk module as well as the root one.
+# Bumps the SDK dependencies to the latest version of the Smithy SDK based on the tags present in the repo
 bump-sdk-version:
 	$(MAKE) bump-go-dep LIB_VERSION=$$(git tag --list --sort="-version:refname" | grep sdk | head -n 1 | sed 's/sdk\///') LIB_URL="github.com/smithy-security/smithy/sdk"
 	@echo "✅✅ Smithy Go SDK version update complete"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smithy-security/smithy
 
-go 1.23.3
+go 1.23.4
 
 toolchain go1.23.7
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/smithy-security/smithy/sdk
 
-go 1.23.2
+go 1.23.4
 
 require (
 	ariga.io/atlas v0.29.0

--- a/smithyctl/go.mod
+++ b/smithyctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/smithy-security/smithy/smithyctl
 
-go 1.23.3
+go 1.23.4
 
 toolchain go1.24.0
 


### PR DESCRIPTION
this PR does a bunch of small fixes left and right:
* fixes our use of caching for the Go tests. building all the binaries for the various components is a CPU intensive job and without all the intermediate artefacts it does take quite some time. if the dependencies are cached this is reduced quite a bit. this run had no caching and it took 22m: https://github.com/smithy-security/smithy/actions/runs/17298936728/job/49104467418 while this one used caching and it took less than 1m: https://github.com/smithy-security/smithy/actions/runs/17299619005/job/49106895430?pr=1076
* adds some phony targets that were missing
* adds a couple of missing docstrings from Makefile