### PR TITLE
Update osv-scanner to use the new sarif package

### DIFF
--- a/components/scanners/osv-scanner/component.yaml
+++ b/components/scanners/osv-scanner/component.yaml
@@ -14,5 +14,5 @@ steps:
     image: components/scanners/osv-scanner
     env_vars:
       RAW_OUT_FILE: "{{ scratchWorkspace }}/output.json"
-      SCANNED_PROJECT_ROOT: "{{ sourceCodeWorkspace }}"
+      WORKSPACE_PATH: "{{ sourceCodeWorkspace }}"
     executable: /bin/app

--- a/components/scanners/osv-scanner/go.mod
+++ b/components/scanners/osv-scanner/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-errors/errors v1.5.1
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/smithy-security/pkg/env v0.0.3
-	github.com/smithy-security/pkg/sarif v0.0.11
+	github.com/smithy-security/pkg/sarif v0.0.14
 	github.com/smithy-security/smithy/sdk v0.0.19-alpha
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/protobuf v1.36.6

--- a/components/scanners/osv-scanner/go.sum
+++ b/components/scanners/osv-scanner/go.sum
@@ -134,8 +134,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smithy-security/pkg/env v0.0.3 h1:eZYRzzFAzWkAJ2OMMhEQr0xSL2mk6cOGpEqcR28QWXM=
 github.com/smithy-security/pkg/env v0.0.3/go.mod h1:VIJfDqeAbQQcmohaXcZI6grjeJC9Y8CmqR4ITpdngZE=
-github.com/smithy-security/pkg/sarif v0.0.11 h1:mzUR1iGgyLum//t1hrecdnz25S4KCRRfBWjw3sLCjkE=
-github.com/smithy-security/pkg/sarif v0.0.11/go.mod h1:fMNL2Uk1fxAAPd4uLUH+zTZ8Fc56rzRmUY2PX2t0X2c=
+github.com/smithy-security/pkg/sarif v0.0.14 h1:dBWrMTTyF8DnfXvdxOojAN+bwVsPC7jgE/tjjVJWMi0=
+github.com/smithy-security/pkg/sarif v0.0.14/go.mod h1:fMNL2Uk1fxAAPd4uLUH+zTZ8Fc56rzRmUY2PX2t0X2c=
 github.com/smithy-security/pkg/utils v0.0.2 h1:r1Gz5eki8xUJXShw4i5ZaizkiKgZlYNYtKE2PDwpoHQ=
 github.com/smithy-security/pkg/utils v0.0.2/go.mod h1:bzCtRv/q9BdCrALRkcWWW3y8DzugbZrEQPwgZ/iepig=
 github.com/smithy-security/smithy/sdk v0.0.19-alpha h1:c+DKDLMNmv6dMu2QQyLUou/Rxx+4c73aO8jmEEK16Pw=

--- a/components/scanners/osv-scanner/internal/transformer/testdata/osv-scan-mismatch-path.sarif.json
+++ b/components/scanners/osv-scanner/internal/transformer/testdata/osv-scan-mismatch-path.sarif.json
@@ -1,0 +1,66 @@
+{
+    "version": "2.1.0",
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+    "runs": [
+      {
+        "tool": {
+          "driver": {
+            "informationUri": "https://github.com/google/osv-scanner",
+            "name": "osv-scanner",
+            "rules": [
+              {
+                "id": "CVE-2025-22869",
+                "name": "CVE-2025-22869",
+                "shortDescription": {
+                  "text": "CVE-2025-22869: Potential denial of service in golang.org/x/crypto"
+                },
+                "fullDescription": {
+                  "text": "SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted.",
+                  "markdown": "SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted."
+                },
+                "deprecatedIds": [
+                  "CVE-2025-22869",
+                  "GO-2025-3487",
+                  "GHSA-hcg3-q754-cr77"
+                ],
+                "help": {
+                  "text": "**Your dependency is vulnerable to [CVE-2025-22869](https://osv.dev/list?q=CVE-2025-22869)**\n(Also published as: [GO-2025-3487](https://osv.dev/vulnerability/GO-2025-3487), [GHSA-hcg3-q754-cr77](https://osv.dev/vulnerability/GHSA-hcg3-q754-cr77), ).\n\n## [GO-2025-3487](https://osv.dev/vulnerability/GO-2025-3487)\n\n<details>\n<summary>Details</summary>\n\n> SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted.\n\n</details>\n\n## [GHSA-hcg3-q754-cr77](https://osv.dev/vulnerability/GHSA-hcg3-q754-cr77)\n\n<details>\n<summary>Details</summary>\n\n> SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted.\n\n</details>\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:/code/sample/go.mod | golang.org/x/crypto | 0.24.0 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-hcg3-q754-cr77 | golang.org/x/crypto | 0.35.0 |\n| GO-2025-3487 | golang.org/x/crypto | 0.35.0 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`/code/sample/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2025-22869\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
+                },
+                "properties": {
+                  "security-severity": "7.5"
+                }
+              }
+            ],
+            "version": "2.0.0"
+          }
+        },
+        "artifacts": [
+          {
+            "location": {
+              "uri": "file:///workspace/source-code/sample/go.mod"
+            },
+            "length": -1
+          }
+        ],
+        "results": [
+          {
+            "ruleId": "CVE-2025-22869",
+            "ruleIndex": 0,
+            "level": "warning",
+            "message": {
+              "text": "Package 'golang.org/x/crypto@0.24.0' is vulnerable to 'CVE-2025-22869' (also known as 'GO-2025-3487', 'GHSA-hcg3-q754-cr77')."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "file:///workspace/source-code//sample/go.mod"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/components/scanners/osv-scanner/internal/transformer/testdata/osv-scan-single-output.sarif.json
+++ b/components/scanners/osv-scanner/internal/transformer/testdata/osv-scan-single-output.sarif.json
@@ -1,0 +1,66 @@
+{
+    "version": "2.1.0",
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+    "runs": [
+      {
+        "tool": {
+          "driver": {
+            "informationUri": "https://github.com/google/osv-scanner",
+            "name": "osv-scanner",
+            "rules": [
+              {
+                "id": "CVE-2025-22869",
+                "name": "CVE-2025-22869",
+                "shortDescription": {
+                  "text": "CVE-2025-22869: Potential denial of service in golang.org/x/crypto"
+                },
+                "fullDescription": {
+                  "text": "SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted.",
+                  "markdown": "SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted."
+                },
+                "deprecatedIds": [
+                  "CVE-2025-22869",
+                  "GO-2025-3487",
+                  "GHSA-hcg3-q754-cr77"
+                ],
+                "help": {
+                  "text": "**Your dependency is vulnerable to [CVE-2025-22869](https://osv.dev/list?q=CVE-2025-22869)**\n(Also published as: [GO-2025-3487](https://osv.dev/vulnerability/GO-2025-3487), [GHSA-hcg3-q754-cr77](https://osv.dev/vulnerability/GHSA-hcg3-q754-cr77), ).\n\n## [GO-2025-3487](https://osv.dev/vulnerability/GO-2025-3487)\n\n<details>\n<summary>Details</summary>\n\n> SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted.\n\n</details>\n\n## [GHSA-hcg3-q754-cr77](https://osv.dev/vulnerability/GHSA-hcg3-q754-cr77)\n\n<details>\n<summary>Details</summary>\n\n> SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted.\n\n</details>\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:/code/sample/go.mod | golang.org/x/crypto | 0.24.0 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-hcg3-q754-cr77 | golang.org/x/crypto | 0.35.0 |\n| GO-2025-3487 | golang.org/x/crypto | 0.35.0 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`/code/sample/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2025-22869\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
+                },
+                "properties": {
+                  "security-severity": "7.5"
+                }
+              }
+            ],
+            "version": "2.0.0"
+          }
+        },
+        "artifacts": [
+          {
+            "location": {
+              "uri": "file:///workspace/source-code/sample/go.mod"
+            },
+            "length": -1
+          }
+        ],
+        "results": [
+          {
+            "ruleId": "CVE-2025-22869",
+            "ruleIndex": 0,
+            "level": "warning",
+            "message": {
+              "text": "Package 'golang.org/x/crypto@0.24.0' is vulnerable to 'CVE-2025-22869' (also known as 'GO-2025-3487', 'GHSA-hcg3-q754-cr77')."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "file:///workspace/source-code//sample/go.mod"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/components/scanners/osv-scanner/internal/transformer/transformer.go
+++ b/components/scanners/osv-scanner/internal/transformer/transformer.go
@@ -57,7 +57,7 @@ var (
 	ErrConstructPath = errors.Errorf("could not construct path for affected code")
 )
 
-// OSVScanneryTransformerWithClock allows customising the underlying clock.
+// OSVScannerTransformerWithClock allows customising the underlying clock.
 func OSVScannerTransformerWithClock(clock clockwork.Clock) OSVScannerTransformerOption {
 	return func(g *OSVScannerTransformer) error {
 		if clock == nil {

--- a/components/scanners/osv-scanner/internal/transformer/transformer_test.go
+++ b/components/scanners/osv-scanner/internal/transformer/transformer_test.go
@@ -140,7 +140,6 @@ func TestTransformer_Transform(t *testing.T) {
 
 	})
 	t.Run("it should return an error, could not construct path for affected code", func(t *testing.T) {
-	t.Run("it should return an error, could not construct path for affected code", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 

--- a/components/scanners/osv-scanner/internal/transformer/transformer_test.go
+++ b/components/scanners/osv-scanner/internal/transformer/transformer_test.go
@@ -46,7 +46,7 @@ func TestTransformer_Transform(t *testing.T) {
 		transformMethodTest(t, ocsfTransformer.Transform, nil, 0)
 	})
 	t.Run("it should return an error when there are malformed results", func(t *testing.T) {
-		os.Setenv("RAW_OUT_FILE", "./testdata/malformed.json")
+		t.Setenv("RAW_OUT_FILE", "./testdata/malformed.json")
 		t.Setenv("WORKSPACE_PATH", "/code")
 		ocsfTransformer, err := New(
 			OSVScannerTransformerWithClock(clock),
@@ -55,6 +55,9 @@ func TestTransformer_Transform(t *testing.T) {
 		transformMethodTest(t, ocsfTransformer.Transform, ErrMalformedSARIFfile, 0)
 	})
 	t.Run("it should extract the relative path from the absolute path", func(t *testing.T) {
+		t.Setenv("RAW_OUT_FILE", "./testdata/osv-scan-single-output.sarif.json")
+		t.Setenv("WORKSPACE_PATH", "/workspace/source-code")
+
 		var (
 			ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
 			clock       = clockwork.NewFakeClockAt(time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC))
@@ -74,9 +77,6 @@ func TestTransformer_Transform(t *testing.T) {
 		}
 
 		ctx = context.WithValue(ctx, component.SCANNER_TARGET_METADATA_CTX_KEY, targetMetadata)
-
-		t.Setenv("RAW_OUT_FILE", "./testdata/osv-scan-single-output.sarif.json")
-		t.Setenv("WORKSPACE_PATH", "/workspace/source-code")
 		ocsfTransformer, err := New(
 			OSVScannerTransformerWithClock(clock),
 		)
@@ -143,6 +143,9 @@ func TestTransformer_Transform(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 
+		t.Setenv("RAW_OUT_FILE", "./testdata/osv-scan-single-output.sarif.json")
+		t.Setenv("WORKSPACE_PATH", "/some-random-path")
+
 		commitRef := "fb00c88b58a57ce73de1871c3b51776386d603fa"
 		repositoryURL := "https://github.com/smithy-security/test"
 		targetMetadata := &ocsffindinginfo.DataSource{
@@ -155,8 +158,6 @@ func TestTransformer_Transform(t *testing.T) {
 
 		ctx = context.WithValue(ctx, component.SCANNER_TARGET_METADATA_CTX_KEY, targetMetadata)
 
-		t.Setenv("RAW_OUT_FILE", "./testdata/osv-scan-single-output.sarif.json")
-		t.Setenv("WORKSPACE_PATH", "/some-random-path")
 		ocsfTransformer, err := New(
 			OSVScannerTransformerWithClock(clock),
 		)

--- a/components/scanners/osv-scanner/vendor/github.com/smithy-security/pkg/sarif/sarif.go
+++ b/components/scanners/osv-scanner/vendor/github.com/smithy-security/pkg/sarif/sarif.go
@@ -32,6 +32,10 @@ type SarifTransformer struct {
 	ruleToEcosystem   map[string]string
 	richDescription   bool
 	dataSource        *ocsffindinginfo.DataSource
+
+	// the root path to which all file paths should be relative to, will be ultimately removed from findings,
+	// this is used to handle CI/CD cases where findings have absolute path to the filesystem as opposed to project root.
+	workspacePath string
 }
 
 var typeName = map[int64]string{
@@ -76,6 +80,7 @@ func NewTransformer(
 	guidProvider StableUUIDProvider,
 	richDescription bool,
 	dataSource *ocsffindinginfo.DataSource,
+	workspacePath string,
 ) (*SarifTransformer, error) {
 	if scanResult == nil {
 		return nil, errors.Errorf("method 'NewTransformer called with nil scanResult")
@@ -97,6 +102,11 @@ func NewTransformer(
 		return nil, errors.Errorf("invalid data source provider: %w", err)
 	}
 
+	cleanedWorkspacePath := filepath.Clean(workspacePath)
+	if !filepath.IsAbs(cleanedWorkspacePath) {
+		return nil, errors.Errorf("workspace path must be an absolute path")
+	}
+
 	return &SarifTransformer{
 		clock:             clock,
 		sarifResult:       *scanResult,
@@ -106,6 +116,7 @@ func NewTransformer(
 		taxasByCWEID:      make(map[string]sarif.ReportingDescriptor),
 		richDescription:   richDescription,
 		dataSource:        dataSource,
+		workspacePath:     cleanedWorkspacePath,
 	}, nil
 }
 
@@ -161,7 +172,10 @@ func (s *SarifTransformer) transformToOCSF(
 	res *sarif.Result,
 ) (*ocsf.VulnerabilityFinding, error) {
 	slog.Debug("parsing run from", slog.String("toolname", toolName))
-	affectedCode, affectedPackages := s.mapAffected(res)
+	affectedCode, affectedPackages, err := s.mapAffected(res)
+	if err != nil {
+		return nil, errors.Errorf("could not map affected code/packages: %w", err)
+	}
 
 	var (
 		ruleID           *string
@@ -346,6 +360,75 @@ func (s *SarifTransformer) isSnykURI(uri string) bool {
 	return strings.HasPrefix(uri, "https_//")
 }
 
+func (s *SarifTransformer) relativePath(path string) (string, error) {
+	if s.workspacePath == "" {
+		return path, nil
+	}
+
+	if !strings.HasPrefix(path, s.workspacePath) {
+		return "", errors.Errorf(
+			"%s: result is not inside expected directory: %s",
+			path,
+			s.workspacePath,
+		)
+	}
+
+	relativePath, err := filepath.Rel(s.workspacePath, path)
+	if err != nil {
+		return "", errors.Errorf(
+			"could not get relative path from path %s using prefix %q",
+			path,
+			s.workspacePath,
+		)
+	}
+
+	return relativePath, nil
+}
+
+// normalisePath will take a given path and construct a file url pointing to
+// the file relative to the workspacePath
+func (s *SarifTransformer) normalisePath(
+	path string,
+	uriBaseId *string,
+) (*ocsf.File, error) {
+	parsedPath, err := url.Parse(path)
+	if err != nil {
+		return nil, errors.Errorf("%s: could not parse path: %w", path, err)
+	}
+
+	cleanedPath := filepath.Clean(
+		filepath.Join(parsedPath.Host, parsedPath.Path),
+	)
+
+	if uriBaseId != nil {
+		slog.Info("path has a non-nil uriBaseId", slog.String("uri_base_id", *uriBaseId))
+	}
+
+	switch {
+	case uriBaseId != nil && strings.ToLower(*uriBaseId) == "%srcroot%" && filepath.IsAbs(cleanedPath):
+		// this should be a relative path and it's not, so we should return an error
+		return nil, errors.Errorf("%s: path was expected to be relative but it's absolute", cleanedPath)
+	case s.workspacePath != "" && filepath.IsAbs(cleanedPath):
+		relativePath, err := s.relativePath(cleanedPath)
+		if err != nil {
+			return nil, err
+		}
+
+		cleanedPath = relativePath
+	}
+
+	// validate that we created a URL correctly
+	finalPath := "file://" + cleanedPath
+	if _, err := url.Parse(finalPath); err != nil {
+		return nil, errors.Errorf("could not parse final path %s as url: %w", finalPath, err)
+	}
+
+	return &ocsf.File{
+		Name: cleanedPath,
+		Path: utils.Ptr(finalPath),
+	}, nil
+}
+
 func (s *SarifTransformer) mapAffectedPackage(fixes []sarif.Fix, purl packageurl.PackageURL) *ocsf.AffectedPackage {
 	affectedPackage := &ocsf.AffectedPackage{
 		Purl:           utils.Ptr(purl.String()),
@@ -440,53 +523,65 @@ func (s *SarifTransformer) rulesToEcosystem() map[string]string {
 	return result
 }
 
-func (s *SarifTransformer) mapAffected(res *sarif.Result) ([]*ocsf.AffectedCode, []*ocsf.AffectedPackage) {
+func (s *SarifTransformer) mapAffected(res *sarif.Result) ([]*ocsf.AffectedCode, []*ocsf.AffectedPackage, error) {
 	var affectedCode []*ocsf.AffectedCode
 	var affectedPackages []*ocsf.AffectedPackage
 	if s.dataSource.TargetType == ocsffindinginfo.DataSource_TARGET_TYPE_WEBSITE { // websites do not carry code or package info
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	for _, location := range res.Locations {
 		if location.PhysicalLocation == nil {
 			continue
 		}
+
 		var (
-			ac = &ocsf.AffectedCode{
-				File: &ocsf.File{},
-			}
 			physicalLocation = location.PhysicalLocation
+			pkgType          = s.findingsEcosystem
+			ruleID           = ""
 		)
-		pkgType := s.findingsEcosystem
-		ruleID := ""
+
 		if res.RuleId != nil {
 			ruleID = *res.RuleId
 		} else if res.Rule != nil && res.Rule.Id != nil {
 			ruleID = *res.Rule.Id
 		}
+
 		if eco, ok := s.ruleToEcosystem[ruleID]; ok {
 			pkgType = eco
 		}
+
 		if physicalLocation.ArtifactLocation != nil && physicalLocation.ArtifactLocation.Uri != nil {
+			uri := *location.PhysicalLocation.ArtifactLocation.Uri
 			if p := s.detectPackageFromPhysicalLocation(*physicalLocation, pkgType); p != nil {
 				affectedPackages = append(affectedPackages, s.mapAffectedPackage(res.Fixes, *p))
-			} else if !s.isSnykURI(*location.PhysicalLocation.ArtifactLocation.Uri) {
 				// Snyk special case, they use the repo url with some weird replacement as the artifact location
-				ac.File.Name = *location.PhysicalLocation.ArtifactLocation.Uri
-				ac.File.Path = utils.Ptr(fmt.Sprintf("file://%s", *location.PhysicalLocation.ArtifactLocation.Uri))
+			} else if !s.isSnykURI(uri) {
+				finalFile, err := s.normalisePath(
+					uri,
+					location.PhysicalLocation.ArtifactLocation.UriBaseId,
+				)
+				if err != nil {
+					return nil, nil, errors.Errorf("could not construct path for affected code: %w", err)
+				}
+
+				ac := &ocsf.AffectedCode{
+					File: finalFile,
+				}
+
+				if physicalLocation.Region != nil {
+					if location.PhysicalLocation.Region.StartLine != nil {
+						ac.StartLine = utils.Ptr(int32(*location.PhysicalLocation.Region.StartLine))
+					}
+					if location.PhysicalLocation.Region.EndLine != nil {
+						ac.EndLine = utils.Ptr(int32(*location.PhysicalLocation.Region.EndLine))
+					}
+				}
+
+				affectedCode = append(affectedCode, ac)
 			}
 		}
-		if physicalLocation.Region != nil {
-			if location.PhysicalLocation.Region.StartLine != nil {
-				ac.StartLine = utils.Ptr(int32(*location.PhysicalLocation.Region.StartLine))
-			}
-			if location.PhysicalLocation.Region.EndLine != nil {
-				ac.EndLine = utils.Ptr(int32(*location.PhysicalLocation.Region.EndLine))
-			}
-		}
-		if ac != (&ocsf.AffectedCode{}) {
-			affectedCode = append(affectedCode, ac)
-		}
+
 		for _, logicalLocation := range location.LogicalLocations {
 			if p := s.detectPackageFromLogicalLocation(logicalLocation, pkgType); p != nil {
 				affectedPackages = append(affectedPackages, s.mapAffectedPackage(res.Fixes, *p))
@@ -494,7 +589,7 @@ func (s *SarifTransformer) mapAffected(res *sarif.Result) ([]*ocsf.AffectedCode,
 		}
 	}
 
-	return affectedCode, affectedPackages
+	return affectedCode, affectedPackages, nil
 }
 
 func (s *SarifTransformer) mapSeverity(sarifResLevel sarif.ResultLevel) ocsf.VulnerabilityFinding_SeverityId {
@@ -567,26 +662,17 @@ func (s *SarifTransformer) mapTitleDesc(res *sarif.Result, ruleToTools map[strin
 		}
 	}
 	if s.richDescription {
-		backUPDescription := descr
-		richInfoAdded := false
-		descr = fmt.Sprintf("Original Description: %s", descr)
 		if rule.Help != nil {
-			if rule.Help.Text != "" {
-				richInfoAdded = true
-				descr = fmt.Sprintf("%s\n Help: %s", descr, rule.Help.Text)
+			if rule.Help.Text != "" && rule.Help.Text != descr {
+				descr = fmt.Sprintf("%s\n\n Help: %s", descr, rule.Help.Text)
 			} else if rule.Help.Markdown != nil && *rule.Help.Markdown != "" {
-				richInfoAdded = true
-				descr = fmt.Sprintf("%s\n Help: %s", descr, *rule.Help.Markdown)
+				descr = fmt.Sprintf("%s\n\n Help: %s", descr, *rule.Help.Markdown)
 			}
 		}
 		if rule.HelpUri != nil && *rule.HelpUri != "" {
-			richInfoAdded = true
-			descr = fmt.Sprintf("%s\n HelpUri: %s", descr, *rule.HelpUri)
+			descr = fmt.Sprintf("%s\n\n More info: %s", descr, *rule.HelpUri)
 		}
-		if !richInfoAdded {
-			// remove the "Original Description:" part since the whole description is the original
-			descr = backUPDescription
-		}
+
 	}
 	return
 }
@@ -616,7 +702,24 @@ func (s *SarifTransformer) mergeDataSources(
 	case ocsffindinginfo.DataSource_TARGET_TYPE_CONTAINER_IMAGE:
 		purl, err := packageurl.FromString("pkg:" + s.findingsEcosystem + "/" + *location.PhysicalLocation.ArtifactLocation.Uri)
 		if err != nil {
-			return nil, errors.Errorf("failed to parse package url:'%s', %v", *location.PhysicalLocation.ArtifactLocation.Uri, err)
+			slog.Error("failed to parse artifact location pURL, falling back to datasource pURL",
+				slog.String("artifact_location_uri", *location.PhysicalLocation.ArtifactLocation.Uri),
+				slog.String("finding_ecosystem", s.findingsEcosystem),
+			)
+
+			if s.dataSource.OciPackageMetadata == nil || s.dataSource.OciPackageMetadata.PackageUrl == "" {
+				return nil, errors.Errorf(
+					"could not parse pURL based on the artifact location URI and no datasource provided: %w",
+					err,
+				)
+			}
+
+			slog.Info("falling back to datasource pURL, this will lead to findings pointing to the artifact itself as finding location")
+			var otherErr error
+			purl, otherErr = packageurl.FromString(s.dataSource.OciPackageMetadata.PackageUrl)
+			if otherErr != nil {
+				return nil, errors.Errorf("could not parse artifact location or datasource pURL: %w: %w", otherErr, err)
+			}
 		}
 
 		dataSource.Uri = &ocsffindinginfo.DataSource_URI{
@@ -634,9 +737,17 @@ func (s *SarifTransformer) mergeDataSources(
 		if s.isSnykURI(*location.PhysicalLocation.ArtifactLocation.Uri) {
 			dataSource.Uri = nil
 		} else {
+			finalPath, err := s.normalisePath(
+				*location.PhysicalLocation.ArtifactLocation.Uri,
+				location.PhysicalLocation.ArtifactLocation.UriBaseId,
+			)
+			if err != nil {
+				return nil, errors.Errorf("could not construct path for repository data source: %w", err)
+			}
+
 			dataSource.Uri = &ocsffindinginfo.DataSource_URI{
 				UriSchema: ocsffindinginfo.DataSource_URI_SCHEMA_FILE,
-				Path:      "file://" + filepath.Clean(*location.PhysicalLocation.ArtifactLocation.Uri),
+				Path:      *finalPath.Path,
 			}
 		}
 

--- a/components/scanners/osv-scanner/vendor/modules.txt
+++ b/components/scanners/osv-scanner/vendor/modules.txt
@@ -135,7 +135,7 @@ github.com/shopspring/decimal
 # github.com/smithy-security/pkg/env v0.0.3
 ## explicit; go 1.23.2
 github.com/smithy-security/pkg/env
-# github.com/smithy-security/pkg/sarif v0.0.11
+# github.com/smithy-security/pkg/sarif v0.0.14
 ## explicit; go 1.23.2
 github.com/smithy-security/pkg/sarif
 github.com/smithy-security/pkg/sarif/spec/gen/sarif-schema/v2-1-0


### PR DESCRIPTION
Output from the json logger, using smithyctl locally

```
{"time":"2025-09-16T15:40:33.822795463Z","level":"INFO","msg":"found finding","sdk_version":"unset","instance_id":"8b414898-0997-49a7-bc1b-0994fdbb7881","component_name":"json-logger","component_type":"reporter","num_findings":35,"finding":"{\"activityId\":\"ACTIVITY_ID_CREATE\",\"activityName\":\"ACTIVITY_ID_CREATE\",\"categoryName\":\"CATEGORY_UID_FINDINGS\",\"categoryUid\":\"CATEGORY_UID_FINDINGS\",\"className\":\"CLASS_UID_VULNERABILITY_FINDING\",\"classUid\":\"CLASS_UID_VULNERABILITY_FINDING\",\"confidence\":\"CONFIDENCE_ID_UNKNOWN\",\"confidenceId\":\"CONFIDENCE_ID_UNKNOWN\",\"count\":1,\"findingInfo\":{\"createdTime\":\"1758037233\",\"createdTimeDt\":\"2025-09-16T15:40:33.631788755Z\",\"dataSources\":[\"{\\\"targetType\\\":\\\"TARGET_TYPE_REPOSITORY\\\",\\\"uri\\\":{\\\"uriSchema\\\":\\\"URI_SCHEMA_FILE\\\",\\\"path\\\":\\\"file://requirements.txt\\\"},\\\"sourceCodeMetadata\\\":{\\\"repositoryUrl\\\":\\\"https://github.com/anxolerd/dvpwa\\\",\\\"reference\\\":\\\"master\\\"}}\"],\"desc\":\"### Impact\\nA specially crafted argument to the `idna.encode()` function could consume significant resources. This may lead to a denial-of-service.\\n\\n### Patches\\nThe function has been refined to reject such strings without the associated resource consumption in version 3.7.\\n\\n### Workarounds\\nDomain names cannot exceed 253 characters in length, if this length limit is enforced prior to passing the domain to the `idna.encode()` function it should no longer consume significant resources. This is triggered by arbitrarily large inputs that would not occur in normal usage, but may be passed to the library assuming there is no preliminary input validation by the higher-level application.\\n\\n### References\\n* https://huntr.com/bounties/93d78d07-d791-4b39-a845-cbfabc44aadb\",\"firstSeenTime\":\"1758037233\",\"firstSeenTimeDt\":\"2025-09-16T15:40:33.631788755Z\",\"lastSeenTime\":\"1758037233\",\"lastSeenTimeDt\":\"2025-09-16T15:40:33.631788755Z\",\"modifiedTime\":\"1758037233\",\"modifiedTimeDt\":\"2025-09-16T15:40:33.631788755Z\",\"productUid\":\"osv-scanner\",\"title\":\"CVE-2024-3651: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode\",\"uid\":\"CVE-2024-3651\"},\"message\":\"### Impact\\nA specially crafted argument to the `idna.encode()` function could consume significant resources. This may lead to a denial-of-service.\\n\\n### Patches\\nThe function has been refined to reject such strings without the associated resource consumption in version 3.7.\\n\\n### Workarounds\\nDomain names cannot exceed 253 characters in length, if this length limit is enforced prior to passing the domain to the `idna.encode()` function it should no longer consume significant resources. This is triggered by arbitrarily large inputs that would not occur in normal usage, but may be passed to the library assuming there is no preliminary input validation by the higher-level application.\\n\\n### References\\n* https://huntr.com/bounties/93d78d07-d791-4b39-a845-cbfabc44aadb\",\"metadata\":{\"eventCode\":\"CVE-2024-3651\",\"product\":{\"name\":\"osv-scanner\"},\"uid\":\"e59d1112-61ad-54d0-b55d-fea467f5e971\"},\"severity\":\"SEVERITY_ID_MEDIUM\",\"severityId\":\"SEVERITY_ID_MEDIUM\",\"startTime\":\"1758037233\",\"status\":\"STATUS_ID_NEW\",\"statusId\":\"STATUS_ID_NEW\",\"time\":\"1758037233\",\"timeDt\":\"2025-09-16T15:40:33.631788755Z\",\"typeName\":\"Create\",\"typeUid\":\"200201\",\"vulnerabilities\":[{\"affectedCode\":[{\"file\":{\"name\":\"requirements.txt\",\"path\":\"file://requirements.txt\"}}],\"cve\":{\"desc\":\"### Impact\\nA specially crafted argument to the `idna.encode()` function could consume significant resources. This may lead to a denial-of-service.\\n\\n### Patches\\nThe function has been refined to reject such strings without the associated resource consumption in version 3.7.\\n\\n### Workarounds\\nDomain names cannot exceed 253 characters in length, if this length limit is enforced prior to passing the domain to the `idna.encode()` function it should no longer consume significant resources. This is triggered by arbitrarily large inputs that would not occur in normal usage, but may be passed to the library assuming there is no preliminary input validation by the higher-level application.\\n\\n### References\\n* https://huntr.com/bounties/93d78d07-d791-4b39-a845-cbfabc44aadb\",\"uid\":\"CVE-2024-3651\"},\"desc\":\"### Impact\\nA specially crafted argument to the `idna.encode()` function could consume significant resources. This may lead to a denial-of-service.\\n\\n### Patches\\nThe function has been refined to reject such strings without the associated resource consumption in version 3.7.\\n\\n### Workarounds\\nDomain names cannot exceed 253 characters in length, if this length limit is enforced prior to passing the domain to the `idna.encode()` function it should no longer consume significant resources. This is triggered by arbitrarily large inputs that would not occur in normal usage, but may be passed to the library assuming there is no preliminary input validation by the higher-level application.\\n\\n### References\\n* https://huntr.com/bounties/93d78d07-d791-4b39-a845-cbfabc44aadb\",\"firstSeenTime\":\"1758037233\",\"firstSeenTimeDt\":\"2025-09-16T15:40:33.631788755Z\",\"fixAvailable\":false,\"isFixAvailable\":false,\"lastSeenTime\":\"1758037233\",\"lastSeenTimeDt\":\"2025-09-16T15:40:33.631788755Z\",\"severity\":\"SEVERITY_ID_MEDIUM\",\"title\":\"CVE-2024-3651: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode\",\"vendorName\":\"osv-scanner\"}]}"}
```

Please note:
- Affected Code now looks like this
`[{\"affectedCode\":[{\"file\":{\"name\":\"requirements.txt\",\"path\":\"file://requirements.txt\"}}]`

and 
`{\\\"uriSchema\\\":\\\"URI_SCHEMA_FILE\\\",\\\"path\\\":\\\"file://requirements.txt\\\"},\\\"sourceCodeMetadata\\\":{\\\"repositoryUrl\\\":\\\"https://github.com/anxolerd/dvpwa\\\",\\\"reference\\\":\\\"master\\\"}}\"],`